### PR TITLE
Add global error handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -8,6 +8,7 @@ from logging.handlers import RotatingFileHandler
 from aiogram import Dispatcher
 
 from handlers.common import router as common_router
+from handlers.error_handler import router as error_router
 from handlers.sprint_actions import router as sprint_router
 from services import bot
 
@@ -37,6 +38,7 @@ def setup_dispatcher() -> Dispatcher:
     dp = Dispatcher()
     dp.include_router(common_router)
     dp.include_router(sprint_router)
+    dp.include_router(error_router)
     return dp
 
 

--- a/handlers/error_handler.py
+++ b/handlers/error_handler.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import logging
+
+from aiogram import Router, types
+
+router = Router()
+
+
+@router.errors(Exception)
+async def global_error_handler(update: types.Update, exception: Exception) -> bool:
+    """Handle unexpected exceptions and notify user."""
+
+    logging.error("Unhandled exception", exc_info=True)
+
+    message = None
+    if isinstance(update, types.Message):
+        message = update
+    elif isinstance(update, types.CallbackQuery):
+        message = update.message
+
+    if message:
+        await message.answer(
+            "Произошла непредвиденная ошибка. Мы уже работаем над этим. Пожалуйста, попробуйте позже."
+        )
+
+    return True


### PR DESCRIPTION
## Summary
- add `handlers/error_handler.py` for global exception handling
- register the handler last in dispatcher

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cca27077c83259319cb4872246c95