### PR TITLE
Improve error handling in handlers

### DIFF
--- a/handlers/common.py
+++ b/handlers/common.py
@@ -42,13 +42,16 @@ async def cmd_reg(message: types.Message) -> None:
 async def reg_contact(message: types.Message) -> None:
     """Save athlete contact."""
     contact = message.contact
-    ws_athletes.append_row(
-        [
-            contact.user_id,
-            contact.first_name or "",
-            datetime.now(timezone.utc).isoformat(" ", "seconds"),
-        ]
-    )
+    try:
+        ws_athletes.append_row(
+            [
+                contact.user_id,
+                contact.first_name or "",
+                datetime.now(timezone.utc).isoformat(" ", "seconds"),
+            ]
+        )
+    except Exception:
+        return await message.answer("Ошибка при сохранении контакта. Попробуйте позже.")
     await message.answer(
         f"✅ Спортсмен {contact.first_name} зареєстрированный.",
         reply_markup=start_kb,


### PR DESCRIPTION
## Summary
- add try/except when saving contact info
- handle DB errors while storing results
- validate athlete ID parsing
- guard athlete list retrieval with error handling

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ccae21fbc8325b61c5d7d16b3964e