### PR TITLE
keyboards: translate button texts

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -13,10 +13,10 @@ def get_stroke_keyboard() -> InlineKeyboardMarkup:
     """Return keyboard for stroke selection."""
     builder = InlineKeyboardBuilder()
     builder.button(
-        text="Вольный стиль", callback_data=StrokeCB(stroke="freestyle").pack()
+        text="Вільний стиль", callback_data=StrokeCB(stroke="freestyle").pack()
     )
-    builder.button(text="Баттерфляй", callback_data=StrokeCB(stroke="butterfly").pack())
-    builder.button(text="Брасс", callback_data=StrokeCB(stroke="breaststroke").pack())
-    builder.button(text="На спине", callback_data=StrokeCB(stroke="backstroke").pack())
+    builder.button(text="Батерфляй", callback_data=StrokeCB(stroke="butterfly").pack())
+    builder.button(text="Брас", callback_data=StrokeCB(stroke="breaststroke").pack())
+    builder.button(text="На спині", callback_data=StrokeCB(stroke="backstroke").pack())
     builder.adjust(2)
     return builder.as_markup()


### PR DESCRIPTION
## Summary
- translate button names in `keyboards.py` to Ukrainian

## Testing
- `pytest -q` *(no tests found)*
- `flake8 keyboards.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f12139fec8325989fc64737204a38