### PR TITLE
Add invite link registration

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,7 @@ from aiogram import Dispatcher
 
 from handlers.common import router as common_router
 from handlers.error_handler import router as error_router
+from handlers.registration import router as registration_router
 from handlers.sprint_actions import router as sprint_router
 from services import bot
 
@@ -36,6 +37,7 @@ logger.addHandler(stream_handler)
 def setup_dispatcher() -> Dispatcher:
     """Configure dispatcher with routers."""
     dp = Dispatcher()
+    dp.include_router(registration_router)
     dp.include_router(common_router)
     dp.include_router(sprint_router)
     dp.include_router(error_router)

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -4,13 +4,9 @@ from datetime import datetime, timezone
 
 from aiogram import Router, types
 from aiogram.filters import Command
-from aiogram.types import (
-    InlineKeyboardButton,
-    InlineKeyboardMarkup,
-    KeyboardButton,
-    ReplyKeyboardMarkup,
-)
+from aiogram.types import KeyboardButton, ReplyKeyboardMarkup
 
+from keyboards import get_main_keyboard
 from services import ADMIN_IDS, ws_athletes
 
 router = Router()
@@ -64,17 +60,7 @@ async def reg_contact(message: types.Message) -> None:
 @router.message(lambda m: m.text == "Старт")
 async def cmd_start(message: types.Message) -> None:
     """Show main menu."""
-    inline_kb = InlineKeyboardMarkup(
-        inline_keyboard=[
-            [InlineKeyboardButton(text="Спринт", callback_data="menu_sprint")],
-            [InlineKeyboardButton(text="Стаєр", callback_data="menu_stayer")],
-            [InlineKeyboardButton(text="Історія", callback_data="menu_history")],
-            [InlineKeyboardButton(text="Рекорди", callback_data="menu_records")],
-            *(
-                [[InlineKeyboardButton(text="Адмін", callback_data="menu_admin")]]
-                if message.from_user.id in ADMIN_IDS
-                else []
-            ),
-        ]
+    is_admin = str(message.from_user.id) in ADMIN_IDS
+    await message.answer(
+        "Оберіть розділ:", reply_markup=get_main_keyboard(is_admin=is_admin)
     )
-    await message.answer("Оберіть розділ:", reply_markup=inline_kb)

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timezone
+
+from aiogram import F, Router, types
+from aiogram.filters import CommandStart
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+
+from keyboards import get_main_keyboard
+from services import ADMIN_IDS, bot, ws_athletes
+
+logger = logging.getLogger(__name__)
+
+router = Router()
+
+# In-memory storage for invite codes
+active_invites: dict[str, int] = {}
+
+
+class RegStates(StatesGroup):
+    """FSM states for athlete registration."""
+
+    waiting_for_name = State()
+
+
+@router.callback_query(F.data == "invite")
+async def send_invite(cb: types.CallbackQuery) -> None:
+    """Generate one-time invite link for a coach."""
+    if str(cb.from_user.id) not in ADMIN_IDS:
+        return await cb.answer("Недостатньо прав.", show_alert=True)
+
+    code = secrets.token_hex(4)
+    active_invites[code] = cb.from_user.id
+    me = await bot.get_me()
+    link = f"https://t.me/{me.username}?start=\u0440\u0435\u0433_{code}"
+
+    await cb.message.answer(f"Надішліть спортсмену це посилання:\n{link}")
+    await cb.answer()
+
+
+@router.message(CommandStart(deep_link=True))
+async def start_with_code(message: types.Message, command: CommandStart.CommandObject, state: FSMContext) -> None:  # type: ignore[attr-defined]
+    """Handle /start with invite code."""
+    args = command.args
+    if not args or not args.startswith("\u0440\u0435\u0433_"):
+        return
+
+    code = args.split("_", 1)[1]
+    if code not in active_invites:
+        await message.answer("Це посилання більше не дійсне.")
+        return
+
+    await state.set_state(RegStates.waiting_for_name)
+    await state.update_data(code=code)
+    await message.answer("Вітаємо! Введіть ваше ім'я та прізвище.")
+
+
+@router.message(RegStates.waiting_for_name)
+async def process_name(message: types.Message, state: FSMContext) -> None:
+    """Save athlete name and finish registration."""
+    data = await state.get_data()
+    code = data.get("code")
+    name = message.text or ""
+    try:
+        ws_athletes.append_row(
+            [
+                message.from_user.id,
+                name,
+                datetime.now(timezone.utc).isoformat(" ", "seconds"),
+            ]
+        )
+    except Exception as e:
+        logger.error(f"Failed to add athlete: {e}")
+        await message.answer("Сталася помилка при збереженні. Спробуйте пізніше.")
+        return
+
+    active_invites.pop(code, None)
+    await state.clear()
+    await message.answer(
+        f"✅ {name} зареєстрований!", reply_markup=get_main_keyboard(is_admin=False)
+    )

--- a/keyboards.py
+++ b/keyboards.py
@@ -8,45 +8,64 @@ from aiogram.types import (
 
 # --- CallbackData Factories ---
 
+
 class StrokeCB(CallbackData, prefix="stroke"):
     stroke: str
+
 
 # --- Reply Keyboards ---
 
 main_keyboard = ReplyKeyboardMarkup(
     keyboard=[
         [KeyboardButton(text="Додати результат ➕")],
-        [KeyboardButton(text="Мої результати 🏆"), KeyboardButton(text="Особисті рекорди 🥇")],
+        [
+            KeyboardButton(text="Мої результати 🏆"),
+            KeyboardButton(text="Особисті рекорди 🥇"),
+        ],
     ],
     resize_keyboard=True,
 )
 
 # --- Inline Keyboards ---
 
+
 def get_stroke_keyboard() -> InlineKeyboardMarkup:
     """Get keyboard for choosing swim stroke."""
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [
-                InlineKeyboardButton(text="🏊‍♂️ Кроль", callback_data=StrokeCB(stroke="freestyle").pack()),
-                InlineKeyboardButton(text="🏊‍♀️ Спина", callback_data=StrokeCB(stroke="backstroke").pack()),
+                InlineKeyboardButton(
+                    text="🏊‍♂️ Кроль", callback_data=StrokeCB(stroke="freestyle").pack()
+                ),
+                InlineKeyboardButton(
+                    text="🏊‍♀️ Спина", callback_data=StrokeCB(stroke="backstroke").pack()
+                ),
             ],
             [
-                InlineKeyboardButton(text="🦋 Батерфляй", callback_data=StrokeCB(stroke="butterfly").pack()),
-                InlineKeyboardButton(text="🐸 Брас", callback_data=StrokeCB(stroke="breaststroke").pack()),
+                InlineKeyboardButton(
+                    text="🦋 Батерфляй",
+                    callback_data=StrokeCB(stroke="butterfly").pack(),
+                ),
+                InlineKeyboardButton(
+                    text="🐸 Брас", callback_data=StrokeCB(stroke="breaststroke").pack()
+                ),
             ],
         ]
     )
+
 
 def get_history_keyboard() -> InlineKeyboardMarkup:
     """Get keyboard with a button to show detailed history."""
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [
-                InlineKeyboardButton(text="📜 Показати детальну історію", callback_data="history")
+                InlineKeyboardButton(
+                    text="📜 Показати детальну історію", callback_data="history"
+                )
             ]
         ]
     )
+
 
 def get_sportsmen_keyboard(sportsmen: list) -> InlineKeyboardMarkup:
     """Gets keyboard with sportsmen names."""
@@ -62,3 +81,23 @@ def get_distance_keyboard(distances: list) -> InlineKeyboardMarkup:
         InlineKeyboardButton(text=f"{dist} м", callback_data=dist) for dist in distances
     ]
     return InlineKeyboardMarkup(inline_keyboard=[buttons])
+
+
+def get_main_keyboard(is_admin: bool = False) -> InlineKeyboardMarkup:
+    """Return main menu keyboard with optional admin buttons."""
+    buttons = [
+        [InlineKeyboardButton(text="Спринт", callback_data="menu_sprint")],
+        [InlineKeyboardButton(text="Стаєр", callback_data="menu_stayer")],
+        [InlineKeyboardButton(text="Історія", callback_data="menu_history")],
+        [InlineKeyboardButton(text="Рекорди", callback_data="menu_records")],
+    ]
+    if is_admin:
+        buttons.append(
+            [
+                InlineKeyboardButton(
+                    text="➕ Запросити спортсмена", callback_data="invite"
+                )
+            ]
+        )
+        buttons.append([InlineKeyboardButton(text="Адмін", callback_data="menu_admin")])
+    return InlineKeyboardMarkup(inline_keyboard=buttons)


### PR DESCRIPTION
## Summary
- generate one-time invite links for coaches
- process deep link registration of athletes
- show "Запросити спортсмена" button in admin menu
- connect new registration router

## Testing
- `isort . && black . && flake8` *(flake8 not installed)*
- `pip install -r requirements.txt` *(fails: no internet)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f44d1832c8325be5d81df51c24493