### PR TITLE
Fix callback timestamp packing and escape comment HTML

### DIFF
--- a/handlers/sprint_actions.py
+++ b/handlers/sprint_actions.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import html
 import json
 import logging
 from dataclasses import dataclass
@@ -99,6 +100,12 @@ def _normalize_comment(comment: str | None) -> str:
     if not comment:
         return ""
     return comment.strip()
+
+
+def _comment_to_html(comment: str) -> str:
+    """Escape comment text for safe HTML rendering."""
+
+    return html.escape(comment, quote=True)
 
 
 def _find_result_row(athlete_id: int, timestamp: str) -> int:
@@ -277,7 +284,7 @@ async def _finalize_result_entry(
             f"🥳 Новий PR сегменту #{i+1}: {fmt_time(t)}" for i, t in new_prs
         )
     if comment_clean:
-        summary += f"\n📝 Нотатка: {comment_clean}"
+        summary += f"\n📝 Нотатка: {_comment_to_html(comment_clean)}"
 
     keyboard = get_result_actions_keyboard(
         athlete_id=athlete_id,
@@ -695,7 +702,7 @@ async def cmd_results(message: types.Message) -> None:
         block_lines = [f"<b>{timestamp}</b> — {dist} м, час {fmt_time(total)}"]
         comment = row[7].strip() if len(row) > 7 else ""
         if comment:
-            block_lines.append(f"📝 {comment}")
+            block_lines.append(f"📝 {_comment_to_html(comment)}")
         if splits:
             block_lines.append(
                 "Спліти: " + " • ".join(fmt_time(float(value)) for value in splits)
@@ -737,7 +744,9 @@ async def history(cb: types.CallbackQuery) -> None:
                             )
 
                     if len(row) > 7 and row[7].strip():
-                        out.append(f"  📝 Нотатка: {row[7].strip()}")
+                        out.append(
+                            f"  📝 Нотатка: {_comment_to_html(row[7].strip())}"
+                        )
 
                     out.append("-" * 20)
                     processed_count += 1

--- a/keyboards.py
+++ b/keyboards.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import binascii
 from typing import Iterable
 
 from aiogram.filters.callback_data import CallbackData
@@ -172,13 +174,19 @@ def get_repeat_keyboard(athlete_id: int) -> InlineKeyboardMarkup:
 def pack_timestamp_for_callback(timestamp: str) -> str:
     """Convert timestamp to callback-friendly format."""
 
-    return timestamp.replace(" ", "_")
+    encoded = base64.urlsafe_b64encode(timestamp.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
 
 
 def unpack_timestamp_from_callback(raw: str) -> str:
     """Restore original timestamp from callback data."""
 
-    return raw.replace("_", " ")
+    try:
+        padding = "=" * (-len(raw) % 4)
+        decoded = base64.urlsafe_b64decode((raw + padding).encode("ascii"))
+        return decoded.decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        return raw.replace("_", " ")
 
 
 def get_comment_prompt_keyboard() -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- encode comment timestamps with URL-safe base64 so callback data never contains reserved separators
- escape stored notes before injecting them into HTML responses to prevent Telegram parse failures

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dba1d0f6048325a86fc11fc5541a12