### PR TITLE
Add role middleware and role-specific menus

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,12 +16,14 @@ from handlers.admin import router as admin_router
 from handlers.backup import router as backup_router
 from handlers.common import router as common_router
 from handlers.error_handler import router as error_router
+from handlers.menu import router as menu_router
 from handlers.messages import router as messages_router
 from handlers.notifications import router as notifications_router
 from handlers.progress import router as progress_router
 from handlers.registration import router as registration_router
 from handlers.sprint_actions import router as sprint_router
 from handlers.templates import router as templates_router
+from middlewares.roles import RoleMiddleware
 from notifications import NotificationService
 from role_service import RoleService
 from services import ADMIN_IDS, bot
@@ -85,6 +87,7 @@ def setup_dispatcher(
     """Configure dispatcher with routers."""
     dp = Dispatcher()
     dp.include_router(registration_router)
+    dp.include_router(menu_router)
     dp.include_router(common_router)
     dp.include_router(add_wizard_router)
     dp.include_router(admin_router)
@@ -124,6 +127,7 @@ async def main() -> None:
         endpoint_url=os.getenv("S3_ENDPOINT_URL") or None,
     )
     dp = setup_dispatcher(notification_service, backup_service)
+    dp.update.middleware(RoleMiddleware(role_service))
     await dp.start_polling(
         bot,
         notifications=notification_service,

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -10,8 +10,8 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
-from filters import RoleFilter
 from role_service import ROLE_ADMIN, ROLE_ATHLETE, ROLE_TRAINER, RoleService
+from utils.roles import require_roles
 
 logger = logging.getLogger(__name__)
 router = Router()
@@ -57,8 +57,8 @@ async def _answer(
         await event.answer()
 
 
-@router.message(Command("admin"), RoleFilter(ROLE_ADMIN))
-@router.callback_query(RoleFilter(ROLE_ADMIN), F.data == "menu_admin")
+@router.message(Command("admin"), require_roles(ROLE_ADMIN))
+@router.callback_query(require_roles(ROLE_ADMIN), F.data == "menu_admin")
 async def open_admin_panel(
     event: types.Message | types.CallbackQuery, state: FSMContext
 ) -> None:
@@ -73,7 +73,7 @@ async def open_admin_panel(
     )
 
 
-@router.callback_query(RoleFilter(ROLE_ADMIN), F.data == "admin:users")
+@router.callback_query(require_roles(ROLE_ADMIN), F.data == "admin:users")
 async def list_users(cb: types.CallbackQuery, role_service: RoleService) -> None:
     """Display current users grouped by roles."""
 
@@ -94,7 +94,7 @@ async def list_users(cb: types.CallbackQuery, role_service: RoleService) -> None
     await cb.answer()
 
 
-@router.callback_query(RoleFilter(ROLE_ADMIN), F.data == "admin:set")
+@router.callback_query(require_roles(ROLE_ADMIN), F.data == "admin:set")
 async def ask_user_for_role(cb: types.CallbackQuery, state: FSMContext) -> None:
     """Ask admin to provide user id for role change."""
 
@@ -103,7 +103,7 @@ async def ask_user_for_role(cb: types.CallbackQuery, state: FSMContext) -> None:
     await cb.answer()
 
 
-@router.message(AdminStates.waiting_user_id, RoleFilter(ROLE_ADMIN))
+@router.message(AdminStates.waiting_user_id, require_roles(ROLE_ADMIN))
 async def select_role_target(
     message: types.Message, state: FSMContext, role_service: RoleService
 ) -> None:
@@ -136,7 +136,7 @@ async def select_role_target(
 
 @router.callback_query(
     AdminStates.waiting_role_choice,
-    RoleFilter(ROLE_ADMIN),
+    require_roles(ROLE_ADMIN),
     F.data.startswith("admin:role:"),
 )
 async def apply_role_change(
@@ -168,7 +168,7 @@ async def apply_role_change(
     await cb.answer()
 
 
-@router.callback_query(RoleFilter(ROLE_ADMIN), F.data == "admin:bind")
+@router.callback_query(require_roles(ROLE_ADMIN), F.data == "admin:bind")
 async def ask_athlete(cb: types.CallbackQuery, state: FSMContext) -> None:
     """Request athlete id to assign a trainer."""
 
@@ -177,7 +177,7 @@ async def ask_athlete(cb: types.CallbackQuery, state: FSMContext) -> None:
     await cb.answer()
 
 
-@router.message(AdminStates.waiting_athlete_id, RoleFilter(ROLE_ADMIN))
+@router.message(AdminStates.waiting_athlete_id, require_roles(ROLE_ADMIN))
 async def choose_trainer(
     message: types.Message, state: FSMContext, role_service: RoleService
 ) -> None:
@@ -219,7 +219,7 @@ async def choose_trainer(
 
 @router.callback_query(
     AdminStates.waiting_trainer_choice,
-    RoleFilter(ROLE_ADMIN),
+    require_roles(ROLE_ADMIN),
     F.data.startswith("admin:trainer:"),
 )
 async def apply_trainer_binding(

--- a/handlers/common.py
+++ b/handlers/common.py
@@ -6,10 +6,9 @@ from aiogram import Router, types
 from aiogram.filters import Command
 from aiogram.types import KeyboardButton, ReplyKeyboardMarkup
 
-from filters import RoleFilter
-from keyboards import get_main_keyboard
 from role_service import ROLE_ADMIN, ROLE_ATHLETE, ROLE_TRAINER, RoleService
 from services import ws_athletes
+from utils.roles import require_roles
 
 router = Router()
 
@@ -24,8 +23,8 @@ start_kb = ReplyKeyboardMarkup(
 )
 
 
-@router.message(Command("reg"), RoleFilter(ROLE_TRAINER, ROLE_ADMIN))
-@router.message(RoleFilter(ROLE_TRAINER, ROLE_ADMIN), lambda m: m.text == "Реєстрація")
+@router.message(Command("reg"), require_roles(ROLE_TRAINER, ROLE_ADMIN))
+@router.message(require_roles(ROLE_TRAINER, ROLE_ADMIN), lambda m: m.text == "Реєстрація")
 async def cmd_reg(message: types.Message) -> None:
     """Request athlete contact."""
     kb = ReplyKeyboardMarkup(
@@ -58,12 +57,3 @@ async def reg_contact(message: types.Message, role_service: RoleService) -> None
         f"✅ Спортсмен {contact.first_name} зареєстрований.",
         reply_markup=start_kb,
     )
-
-
-@router.message(Command("start"))
-@router.message(lambda m: m.text == "Старт")
-async def cmd_start(message: types.Message, role_service: RoleService) -> None:
-    """Show main menu."""
-    await role_service.upsert_user(message.from_user)
-    role = await role_service.get_role(message.from_user.id)
-    await message.answer("Оберіть розділ:", reply_markup=get_main_keyboard(role))

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -1,0 +1,113 @@
+"""Role-aware menu handlers."""
+
+from __future__ import annotations
+
+from aiogram import F, Router, types
+from aiogram.filters import Command, CommandStart
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from role_service import ROLE_ADMIN, ROLE_ATHLETE, ROLE_TRAINER, RoleService
+from utils.roles import require_roles
+
+router = Router()
+
+_MENU_TEXT = "Выберите раздел:"  # TODO: подключить i18n при доступности
+
+
+def _row(*buttons: InlineKeyboardButton) -> list[InlineKeyboardButton]:
+    return list(buttons)
+
+
+def _menu_keyboard_for_manager() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            _row(InlineKeyboardButton(text="Добавить результат", callback_data="menu_sprint")),
+            _row(InlineKeyboardButton(text="Шаблоны", callback_data="menu_templates")),
+            _row(InlineKeyboardButton(text="Отчёты", callback_data="menu_reports")),
+            _row(InlineKeyboardButton(text="Поиск/История", callback_data="menu_history")),
+        ]
+    )
+
+
+def _menu_keyboard_for_athlete() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            _row(InlineKeyboardButton(text="Мои результаты", callback_data="menu_history")),
+            _row(InlineKeyboardButton(text="Мой прогресс", callback_data="menu_progress")),
+        ]
+    )
+
+
+def build_menu_keyboard(role: str) -> InlineKeyboardMarkup:
+    """Return inline keyboard for the provided role."""
+
+    if role == ROLE_ATHLETE:
+        return _menu_keyboard_for_athlete()
+    keyboard = _menu_keyboard_for_manager()
+    if role == ROLE_ADMIN:
+        keyboard.inline_keyboard.append(
+            _row(InlineKeyboardButton(text="Админ-раздел", callback_data="menu_admin"))
+        )
+    return keyboard
+
+
+async def _resolve_role(message: types.Message, role_service: RoleService, user_role: str | None) -> str:
+    await role_service.upsert_user(message.from_user)
+    if user_role:
+        return user_role
+    return await role_service.get_role(message.from_user.id)
+
+
+async def _send_menu(
+    message: types.Message, role_service: RoleService, user_role: str | None
+) -> None:
+    role = await _resolve_role(message, role_service, user_role)
+    await message.answer(_MENU_TEXT, reply_markup=build_menu_keyboard(role))
+
+
+@router.message(CommandStart())
+async def cmd_start(
+    message: types.Message, role_service: RoleService, user_role: str | None = None
+) -> None:
+    """Show menu depending on user role."""
+
+    await _send_menu(message, role_service, user_role)
+
+
+@router.message(Command("menu"))
+async def cmd_menu(
+    message: types.Message, role_service: RoleService, user_role: str | None = None
+) -> None:
+    """Explicit command to reopen main menu."""
+
+    await _send_menu(message, role_service, user_role)
+
+
+@router.message(F.text == "Старт")
+async def start_button(
+    message: types.Message, role_service: RoleService, user_role: str | None = None
+) -> None:
+    """Handle reply keyboard start button."""
+
+    await _send_menu(message, role_service, user_role)
+
+
+@router.callback_query(F.data == "menu_reports")
+@require_roles(ROLE_TRAINER, ROLE_ADMIN)
+async def menu_reports(cb: types.CallbackQuery) -> None:
+    """Placeholder for coach/admin report section."""
+
+    await cb.message.answer("Раздел отчётов находится в разработке.")
+    await cb.answer()
+
+
+@router.callback_query(F.data == "menu_progress")
+async def menu_progress_redirect(
+    cb: types.CallbackQuery, role_service: RoleService
+) -> None:
+    """Redirect progress menu button to the existing progress flow."""
+
+    from handlers.progress import cmd_progress
+
+    await cmd_progress(cb.message, role_service)
+    await cb.answer()

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -9,10 +9,10 @@ from aiogram.filters import CommandStart
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 
-from filters import RoleFilter
-from keyboards import get_main_keyboard
+from handlers.menu import build_menu_keyboard
 from role_service import ROLE_ATHLETE, ROLE_TRAINER, RoleService
 from services import bot, ws_athletes
+from utils.roles import require_roles
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class RegStates(StatesGroup):
     waiting_for_name = State()
 
 
-@router.callback_query(RoleFilter(ROLE_TRAINER), F.data == "invite")
+@router.callback_query(require_roles(ROLE_TRAINER), F.data == "invite")
 async def send_invite(cb: types.CallbackQuery, role_service: RoleService) -> None:
     """Generate one-time invite link for a coach."""
 
@@ -93,5 +93,5 @@ async def process_name(
         await role_service.set_trainer(message.from_user.id, int(trainer_id))
     await state.clear()
     await message.answer(
-        f"✅ {name} зареєстрований!", reply_markup=get_main_keyboard(ROLE_ATHLETE)
+        f"✅ {name} зареєстрований!", reply_markup=build_menu_keyboard(ROLE_ATHLETE)
     )

--- a/handlers/templates.py
+++ b/handlers/templates.py
@@ -230,6 +230,23 @@ async def templates_menu(
     await _show_list(message, template_service)
 
 
+@router.callback_query(F.data == "menu_templates")
+async def menu_templates(
+    cb: types.CallbackQuery,
+    state: FSMContext,
+    template_service: TemplateService,
+    role_service: RoleService,
+) -> None:
+    """Open templates menu from the main menu."""
+
+    if not await _is_manager(cb.from_user, role_service):
+        await cb.answer("Недостатньо прав", show_alert=True)
+        return
+    await state.clear()
+    await state.set_state(TemplateStates.menu)
+    await _show_list(cb, template_service)
+
+
 @router.callback_query(TemplateCB.filter())
 async def template_actions(
     cb: types.CallbackQuery,

--- a/middlewares/roles.py
+++ b/middlewares/roles.py
@@ -1,0 +1,34 @@
+"""Middleware for injecting user role into handler context."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict
+
+from aiogram import BaseMiddleware
+from aiogram.types import TelegramObject
+
+from role_service import RoleService
+
+Handler = Callable[[TelegramObject, Dict[str, Any]], Awaitable[Any]]
+
+
+class RoleMiddleware(BaseMiddleware):
+    """Populate handler data with the current user's role."""
+
+    def __init__(self, role_service: RoleService, *, context_key: str = "user_role") -> None:
+        self._role_service = role_service
+        self._context_key = context_key
+
+    async def __call__(
+        self, handler: Handler, event: TelegramObject, data: Dict[str, Any]
+    ) -> Any:
+        if self._context_key in data:
+            return await handler(event, data)
+
+        user = getattr(event, "from_user", None)
+        if user is None:
+            return await handler(event, data)
+
+        role = await self._role_service.get_role(user.id)
+        data[self._context_key] = role
+        return await handler(event, data)

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,70 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from middlewares.roles import RoleMiddleware
+from utils.roles import RequireRolesFilter, require_roles
+
+
+class StubRoleService:
+    def __init__(self, mapping: dict[int, str]) -> None:
+        self.mapping = mapping
+
+    async def get_role(self, user_id: int) -> str:
+        return self.mapping.get(user_id, "athlete")
+
+
+def test_require_roles_accepts_role_from_context() -> None:
+    filt = require_roles("admin")
+    event = SimpleNamespace(from_user=SimpleNamespace(id=1))
+    data = {"user_role": "admin"}
+    assert asyncio.run(filt(event, data))
+
+
+def test_require_roles_fetches_role_from_service() -> None:
+    service = StubRoleService({2: "coach"})
+    filt = require_roles("coach")
+    event = SimpleNamespace(from_user=SimpleNamespace(id=2))
+    data = {"role_service": service}
+    assert asyncio.run(filt(event, data))
+    assert data["user_role"] == "coach"
+
+
+def test_require_roles_denies_without_service() -> None:
+    filt = require_roles("admin")
+    event = SimpleNamespace(from_user=SimpleNamespace(id=3))
+    assert not asyncio.run(filt(event, {}))
+
+
+def test_require_roles_denies_when_user_missing() -> None:
+    filt = require_roles("admin")
+    event = SimpleNamespace()
+    assert not asyncio.run(filt(event, {"role_service": StubRoleService({})}))
+
+
+def test_require_roles_extend_creates_new_filter() -> None:
+    base = RequireRolesFilter("coach")
+    extended = base.extend(["admin"])
+    assert base is not extended
+    assert base.allowed_roles == {"coach"}
+    assert extended.allowed_roles == {"coach", "admin"}
+
+
+def test_require_roles_raises_without_roles() -> None:
+    with pytest.raises(ValueError):
+        require_roles()
+
+
+def test_role_middleware_injects_role() -> None:
+    service = StubRoleService({5: "admin"})
+    middleware = RoleMiddleware(service)
+    event = SimpleNamespace(from_user=SimpleNamespace(id=5))
+    data: dict[str, str] = {}
+
+    async def handler(evt, ctx):
+        return ctx["user_role"], ctx is data
+
+    role, same_data = asyncio.run(middleware(handler, event, data))
+    assert role == "admin"
+    assert same_data

--- a/utils/roles.py
+++ b/utils/roles.py
@@ -1,0 +1,44 @@
+"""Role-based access helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Set
+
+from aiogram.filters import BaseFilter
+from aiogram.types import TelegramObject
+
+from role_service import RoleService
+
+DEFAULT_ROLE_KEY = "user_role"
+
+
+class RequireRolesFilter(BaseFilter):
+    """Filter allowing events only for specific roles."""
+
+    def __init__(self, *roles: str, context_key: str = DEFAULT_ROLE_KEY) -> None:
+        if not roles:
+            raise ValueError("require_roles() expects at least one role")
+        self.allowed_roles: Set[str] = set(roles)
+        self.context_key = context_key
+
+    async def __call__(self, event: TelegramObject, data: Dict[str, Any]) -> bool:
+        role = data.get(self.context_key)
+        if role is None:
+            role_service: RoleService | None = data.get("role_service")
+            user = getattr(event, "from_user", None)
+            if role_service is None or user is None:
+                return False
+            role = await role_service.get_role(user.id)
+            data[self.context_key] = role
+        return str(role) in self.allowed_roles
+
+    def extend(self, roles: Iterable[str]) -> "RequireRolesFilter":
+        """Return new filter instance with additional roles allowed."""
+
+        return RequireRolesFilter(*self.allowed_roles.union(set(roles)), context_key=self.context_key)
+
+
+def require_roles(*roles: str, context_key: str = DEFAULT_ROLE_KEY) -> RequireRolesFilter:
+    """Shortcut returning :class:`RequireRolesFilter` instance."""
+
+    return RequireRolesFilter(*roles, context_key=context_key)


### PR DESCRIPTION
## Summary
- add a middleware to inject user roles into handler context and a reusable require_roles filter
- introduce a dedicated menu handler with role-specific options and restrict admin flows with the new filter
- add tests covering role filtering behaviour and callbacks

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddb69e0e4883258e967469149286a8