### PR TITLE
Add onboarding FSM for new users

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,7 @@ from handlers.error_handler import router as error_router
 from handlers.menu import router as menu_router
 from handlers.messages import router as messages_router
 from handlers.notifications import router as notifications_router
+from handlers.onboarding import router as onboarding_router
 from handlers.progress import router as progress_router
 from handlers.registration import router as registration_router
 from handlers.sprint_actions import router as sprint_router
@@ -27,6 +28,7 @@ from middlewares.roles import RoleMiddleware
 from notifications import NotificationService
 from role_service import RoleService
 from services import ADMIN_IDS, bot
+from services.user_service import UserService
 from template_service import TemplateService
 
 LOG_DIR = "logs"
@@ -87,6 +89,7 @@ def setup_dispatcher(
     """Configure dispatcher with routers."""
     dp = Dispatcher()
     dp.include_router(registration_router)
+    dp.include_router(onboarding_router)
     dp.include_router(menu_router)
     dp.include_router(common_router)
     dp.include_router(add_wizard_router)
@@ -114,6 +117,8 @@ async def main() -> None:
     admin_chat_ids = _parse_admin_chat_ids()
     role_service = RoleService()
     await role_service.init(admin_ids=admin_chat_ids)
+    user_service = UserService()
+    await user_service.init()
     template_service = TemplateService()
     await template_service.init()
     backup_service = BackupService(
@@ -134,6 +139,7 @@ async def main() -> None:
         chat_service=chat_service,
         backup_service=backup_service,
         role_service=role_service,
+        user_service=user_service,
         template_service=template_service,
     )
 

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from aiogram import F, Router, types
-from aiogram.filters import Command, CommandStart
+from aiogram.filters import Command
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from role_service import ROLE_ADMIN, ROLE_ATHLETE, ROLE_TRAINER, RoleService
@@ -65,15 +65,6 @@ async def _send_menu(
     await message.answer(_MENU_TEXT, reply_markup=build_menu_keyboard(role))
 
 
-@router.message(CommandStart())
-async def cmd_start(
-    message: types.Message, role_service: RoleService, user_role: str | None = None
-) -> None:
-    """Show menu depending on user role."""
-
-    await _send_menu(message, role_service, user_role)
-
-
 @router.message(Command("menu"))
 async def cmd_menu(
     message: types.Message, role_service: RoleService, user_role: str | None = None
@@ -92,8 +83,7 @@ async def start_button(
     await _send_menu(message, role_service, user_role)
 
 
-@router.callback_query(F.data == "menu_reports")
-@require_roles(ROLE_TRAINER, ROLE_ADMIN)
+@router.callback_query(require_roles(ROLE_TRAINER, ROLE_ADMIN), F.data == "menu_reports")
 async def menu_reports(cb: types.CallbackQuery) -> None:
     """Placeholder for coach/admin report section."""
 

--- a/handlers/onboarding.py
+++ b/handlers/onboarding.py
@@ -1,0 +1,216 @@
+"""FSM onboarding flow for new users."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+from aiogram import F, Router
+from aiogram.filters import CommandStart
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, Message
+
+from handlers.menu import build_menu_keyboard
+from keyboards import (
+    get_onboarding_language_keyboard,
+    get_onboarding_role_keyboard,
+    get_onboarding_skip_keyboard,
+    OnboardingLanguageCB,
+    OnboardingRoleCB,
+)
+from role_service import ROLE_ATHLETE, ROLE_TRAINER, RoleService
+from services.user_service import UserProfile, UserService
+
+logger = logging.getLogger(__name__)
+
+router = Router()
+
+_NAME_PATTERN = re.compile(r"^[A-Za-zА-Яа-яЁёІіЇїЄєҐґ0-9'’`\-\.\s]+$")
+_MIN_NAME_LENGTH = 2
+_MAX_NAME_LENGTH = 64
+
+_LANGUAGE_LABELS = {"uk": "Українська", "ru": "Русский"}
+_ROLE_LABELS = {ROLE_TRAINER: "Тренер", ROLE_ATHLETE: "Спортсмен"}
+
+
+class Onboarding(StatesGroup):
+    """FSM states for onboarding."""
+
+    choosing_role = State()
+    entering_name = State()
+    entering_group = State()
+    choosing_language = State()
+
+
+def _clean_text(raw: str) -> str:
+    return " ".join(raw.split())
+
+
+def _validate_name(value: str) -> Optional[str]:
+    """Return cleaned name if valid, otherwise ``None``."""
+
+    cleaned = _clean_text(value)
+    if not (_MIN_NAME_LENGTH <= len(cleaned) <= _MAX_NAME_LENGTH):
+        return None
+    if not _NAME_PATTERN.match(cleaned):
+        return None
+    return cleaned
+
+
+def _format_profile(profile: UserProfile) -> str:
+    role_label = _ROLE_LABELS.get(profile.role, profile.role.title())
+    language_label = _LANGUAGE_LABELS.get(profile.language, profile.language)
+    group_line = profile.group_name or "—"
+    return (
+        "Ваш профиль готов!\n"
+        f"Роль: <b>{role_label}</b>\n"
+        f"Имя: <b>{profile.full_name}</b>\n"
+        f"Группа: <b>{group_line}</b>\n"
+        f"Язык: <b>{language_label}</b>"
+    )
+
+
+@router.message(CommandStart())
+async def start_onboarding(
+    message: Message,
+    state: FSMContext,
+    user_service: UserService,
+    role_service: RoleService,
+) -> None:
+    """Handle /start: run onboarding or show profile."""
+
+    await state.clear()
+    user_id = message.from_user.id
+    profile = await user_service.get_profile(user_id)
+    if profile:
+        await role_service.set_role(user_id, profile.role)
+        await message.answer(
+            _format_profile(profile), reply_markup=build_menu_keyboard(profile.role)
+        )
+        return
+
+    await state.set_state(Onboarding.choosing_role)
+    await message.answer(
+        "Привет! Давайте настроим ваш профиль. Выберите вашу роль:",
+        reply_markup=get_onboarding_role_keyboard(),
+    )
+    return
+
+
+@router.callback_query(Onboarding.choosing_role, OnboardingRoleCB.filter())
+async def process_role(
+    callback: CallbackQuery,
+    callback_data: OnboardingRoleCB,
+    state: FSMContext,
+) -> None:
+    """Save chosen role and ask for name."""
+
+    role = callback_data.role
+    await state.update_data(role=role)
+    await state.set_state(Onboarding.entering_name)
+    await callback.message.edit_reply_markup()
+    await callback.message.answer(
+        "Отлично! Теперь введите ваше имя и фамилию (2-64 символа, без спецсимволов)."
+    )
+    await callback.answer()
+
+
+@router.message(Onboarding.entering_name, F.text)
+async def process_name(message: Message, state: FSMContext) -> None:
+    """Validate and store user name."""
+
+    name = message.text or ""
+    cleaned = _validate_name(name)
+    if not cleaned:
+        await message.answer(
+            "Имя должно содержать от 2 до 64 символов и не включать спецсимволы."
+        )
+        return
+    await state.update_data(full_name=cleaned)
+    await state.set_state(Onboarding.entering_group)
+    await message.answer(
+        "Укажите группу/клуб (опционально) или пропустите шаг:",
+        reply_markup=get_onboarding_skip_keyboard(),
+    )
+
+
+async def _proceed_to_language(state: FSMContext, message: Message) -> None:
+    await state.set_state(Onboarding.choosing_language)
+    await message.answer(
+        "Выберите язык интерфейса:",
+        reply_markup=get_onboarding_language_keyboard(),
+    )
+
+
+@router.message(Onboarding.entering_group, F.text)
+async def process_group(message: Message, state: FSMContext) -> None:
+    """Store provided group or skip if requested."""
+
+    text = message.text or ""
+    if text.casefold() in {"пропустить", "skip", "-"}:
+        await state.update_data(group_name=None)
+    else:
+        cleaned = text.strip()
+        if cleaned:
+            await state.update_data(group_name=cleaned[:80])
+        else:
+            await state.update_data(group_name=None)
+    await message.answer("Шаг сохранён.")
+    await _proceed_to_language(state, message)
+
+
+@router.callback_query(Onboarding.entering_group, F.data == "onboard_skip_group")
+async def skip_group_callback(callback: CallbackQuery, state: FSMContext) -> None:
+    """Handle inline skip for group step."""
+
+    await state.update_data(group_name=None)
+    await callback.message.edit_reply_markup()
+    await callback.answer("Пропущено")
+    await _proceed_to_language(state, callback.message)
+
+
+@router.callback_query(Onboarding.choosing_language, OnboardingLanguageCB.filter())
+async def process_language(
+    callback: CallbackQuery,
+    callback_data: OnboardingLanguageCB,
+    state: FSMContext,
+    user_service: UserService,
+    role_service: RoleService,
+) -> None:
+    """Persist profile and finish onboarding."""
+
+    language = callback_data.language
+    data = await state.get_data()
+    role = data.get("role", ROLE_ATHLETE)
+    full_name = data.get("full_name")
+    group_name = data.get("group_name")
+    user_id = callback.from_user.id
+
+    if not full_name:
+        logger.warning("Missing name in onboarding state for %s", user_id)
+        await callback.answer("Произошла ошибка, начните заново.", show_alert=True)
+        await state.clear()
+        return
+
+    await user_service.upsert_profile(
+        user_id,
+        role=role,
+        full_name=full_name,
+        language=language,
+        group_name=group_name,
+    )
+    await role_service.set_role(user_id, role)
+    profile = await user_service.get_profile(user_id)
+    await state.clear()
+    await callback.message.edit_reply_markup()
+    if profile:
+        await callback.message.answer(
+            _format_profile(profile), reply_markup=build_menu_keyboard(profile.role)
+        )
+    else:
+        await callback.message.answer(
+            "Профиль сохранён.", reply_markup=build_menu_keyboard(role)
+        )
+    await callback.answer("Готово!")

--- a/keyboards.py
+++ b/keyboards.py
@@ -12,7 +12,7 @@ from aiogram.types import (
     ReplyKeyboardMarkup,
 )
 
-from role_service import ROLE_ADMIN, ROLE_TRAINER
+from role_service import ROLE_ADMIN, ROLE_ATHLETE, ROLE_TRAINER
 
 # --- CallbackData Factories ---
 
@@ -52,6 +52,18 @@ class AddWizardCB(CallbackData, prefix="aw"):
 
     action: str
     value: str = ""
+
+
+class OnboardingRoleCB(CallbackData, prefix="onbrole"):
+    """Callback data for onboarding role selection."""
+
+    role: str
+
+
+class OnboardingLanguageCB(CallbackData, prefix="onblang"):
+    """Callback data for onboarding language selection."""
+
+    language: str
 
 
 # --- Reply Keyboards ---
@@ -174,6 +186,58 @@ def get_repeat_keyboard(athlete_id: int) -> InlineKeyboardMarkup:
                 InlineKeyboardButton(
                     text="🔁 Повторити попередній результат",
                     callback_data=RepeatCB(athlete_id=athlete_id).pack(),
+                )
+            ]
+        ]
+    )
+
+
+def get_onboarding_role_keyboard() -> InlineKeyboardMarkup:
+    """Return keyboard with onboarding role options."""
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Я тренер",
+                    callback_data=OnboardingRoleCB(role=ROLE_TRAINER).pack(),
+                ),
+                InlineKeyboardButton(
+                    text="Я спортсмен",
+                    callback_data=OnboardingRoleCB(role=ROLE_ATHLETE).pack(),
+                ),
+            ]
+        ]
+    )
+
+
+def get_onboarding_language_keyboard() -> InlineKeyboardMarkup:
+    """Return keyboard with language choices."""
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Українська",
+                    callback_data=OnboardingLanguageCB(language="uk").pack(),
+                ),
+                InlineKeyboardButton(
+                    text="Русский",
+                    callback_data=OnboardingLanguageCB(language="ru").pack(),
+                ),
+            ]
+        ]
+    )
+
+
+def get_onboarding_skip_keyboard() -> InlineKeyboardMarkup:
+    """Inline keyboard allowing to skip optional step."""
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Пропустить", callback_data="onboard_skip_group"
                 )
             ]
         ]

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,26 @@
+"""Service access facade with lazy initialisation."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_BASE_MODULE: ModuleType | None = None
+
+
+def _load_base() -> ModuleType:
+    global _BASE_MODULE
+    if _BASE_MODULE is None:
+        _BASE_MODULE = import_module(".base", __name__)
+    return _BASE_MODULE
+
+
+def __getattr__(name: str) -> Any:
+    base = _load_base()
+    return getattr(base, name)
+
+
+def __dir__() -> list[str]:
+    base = _load_base()
+    return sorted(set(globals().keys()) | set(dir(base)))

--- a/services/base.py
+++ b/services/base.py
@@ -1,3 +1,7 @@
+"""Legacy service initialisation utilities."""
+
+from __future__ import annotations
+
 import logging
 import os
 from functools import lru_cache
@@ -34,11 +38,12 @@ except gspread.exceptions.SpreadsheetNotFound:
     raise
 except gspread.exceptions.WorksheetNotFound as e:
     logging.error(
-        f"Worksheet not found: {e}. Make sure all worksheets (results, pr, log, AthletesList) exist."
+        "Worksheet not found: %s. Make sure all worksheets (results, pr, log, AthletesList) exist.",
+        e,
     )
     raise
-except Exception as e:
-    logging.error(f"An error occurred during Google Sheets initialization: {e}")
+except Exception as e:  # pragma: no cover - unexpected init errors
+    logging.error("An error occurred during Google Sheets initialization: %s", e)
     raise
 
 # --- Constants and Helpers ---
@@ -48,11 +53,12 @@ ADMIN_IDS = (os.getenv("ADMIN_IDS") or "").split(",")
 @lru_cache(maxsize=1)
 def get_all_sportsmen() -> list[str]:
     """Get a list of all sportsmen's names."""
+
     try:
         # Assuming names are in the second column (B) starting from the second row
         return ws_athletes.col_values(2)[1:]
-    except Exception as e:
-        logging.error(f"Failed to get sportsmen list from Google Sheets: {e}")
+    except Exception as e:  # pragma: no cover - relies on external service
+        logging.error("Failed to get sportsmen list from Google Sheets: %s", e)
         return []
 
 
@@ -61,7 +67,7 @@ def get_registered_athletes() -> list[tuple[int, str]]:
 
     try:
         rows = ws_athletes.get_all_values()
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - relies on external service
         logging.error("Failed to fetch athletes: %s", e)
         return []
 

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -1,0 +1,151 @@
+"""User profile storage and onboarding helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+_SETUP_SCRIPT = """
+CREATE TABLE IF NOT EXISTS user_profiles (
+    telegram_id INTEGER PRIMARY KEY,
+    role TEXT NOT NULL,
+    full_name TEXT NOT NULL,
+    group_name TEXT DEFAULT NULL,
+    language TEXT NOT NULL DEFAULT 'ru',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+
+@dataclass(slots=True)
+class UserProfile:
+    """User profile stored in SQLite."""
+
+    telegram_id: int
+    role: str
+    full_name: str
+    group_name: Optional[str]
+    language: str
+
+
+class UserService:
+    """Persist and retrieve user onboarding data."""
+
+    def __init__(self, db_path: Path | str = Path("data/user_profiles.db")) -> None:
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    async def init(self) -> None:
+        """Initialise storage schema."""
+
+        async with self._lock:
+            await asyncio.to_thread(self._ensure_schema)
+
+    async def get_profile(self, telegram_id: int) -> Optional[UserProfile]:
+        """Return stored profile if present."""
+
+        row = await asyncio.to_thread(self._fetch_profile, telegram_id)
+        if row is None:
+            return None
+        return UserProfile(
+            telegram_id=row["telegram_id"],
+            role=row["role"],
+            full_name=row["full_name"],
+            group_name=row["group_name"],
+            language=row["language"],
+        )
+
+    async def upsert_profile(
+        self,
+        telegram_id: int,
+        *,
+        role: str,
+        full_name: str,
+        language: str,
+        group_name: Optional[str] = None,
+    ) -> None:
+        """Create or update profile data."""
+
+        await asyncio.to_thread(
+            self._upsert_profile,
+            telegram_id,
+            role,
+            full_name,
+            language,
+            group_name,
+        )
+
+    async def update_language(self, telegram_id: int, language: str) -> None:
+        """Update language preference for a user."""
+
+        await asyncio.to_thread(self._update_field, telegram_id, "language", language)
+
+    async def update_group(self, telegram_id: int, group_name: Optional[str]) -> None:
+        """Update group/club for a user."""
+
+        await asyncio.to_thread(self._update_field, telegram_id, "group_name", group_name)
+
+    async def update_name(self, telegram_id: int, full_name: str) -> None:
+        """Update full name for a user."""
+
+        await asyncio.to_thread(self._update_field, telegram_id, "full_name", full_name)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(_SETUP_SCRIPT)
+            conn.commit()
+
+    def _fetch_profile(self, telegram_id: int) -> Optional[sqlite3.Row]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "SELECT telegram_id, role, full_name, group_name, language FROM user_profiles WHERE telegram_id = ?",
+                (telegram_id,),
+            )
+            return cursor.fetchone()
+
+    def _upsert_profile(
+        self,
+        telegram_id: int,
+        role: str,
+        full_name: str,
+        language: str,
+        group_name: Optional[str],
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO user_profiles (telegram_id, role, full_name, language, group_name)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(telegram_id) DO UPDATE SET
+                    role = excluded.role,
+                    full_name = excluded.full_name,
+                    language = excluded.language,
+                    group_name = excluded.group_name,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (telegram_id, role, full_name, language, group_name),
+            )
+            conn.commit()
+
+    def _update_field(self, telegram_id: int, field: str, value: Optional[str]) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                f"""
+                UPDATE user_profiles
+                SET {field} = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE telegram_id = ?
+                """,
+                (value, telegram_id),
+            )
+            conn.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("BOT_TOKEN", "test-token")

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from handlers.onboarding import _format_profile, _validate_name
+from role_service import ROLE_ATHLETE, ROLE_TRAINER
+from services.user_service import UserProfile, UserService
+
+
+def test_validate_name_accepts_valid_samples() -> None:
+    assert _validate_name("Іван Петренко") == "Іван Петренко"
+    assert _validate_name("Anna-Maria") == "Anna-Maria"
+
+
+def test_validate_name_rejects_invalid_values() -> None:
+    assert _validate_name("a") is None
+    assert _validate_name("Имя!!!") is None
+
+
+def test_format_profile_renders_labels() -> None:
+    profile = UserProfile(
+        telegram_id=1,
+        role=ROLE_TRAINER,
+        full_name="Coach",
+        group_name="Sharks",
+        language="uk",
+    )
+    text = _format_profile(profile)
+    assert "Тренер" in text
+    assert "Українська" in text
+
+
+def test_user_service_roundtrip(tmp_path: Path) -> None:
+    db_dir = tmp_path / "db"
+    db_dir.mkdir()
+    path = db_dir / "users.db"
+    service = UserService(path)
+
+    async def scenario() -> None:
+        await service.init()
+
+        await service.upsert_profile(
+            42,
+            role=ROLE_ATHLETE,
+            full_name="Athlete Name",
+            language="ru",
+        )
+
+        profile = await service.get_profile(42)
+        assert profile is not None
+        assert profile.role == ROLE_ATHLETE
+        assert profile.language == "ru"
+
+        await service.upsert_profile(
+            42,
+            role=ROLE_TRAINER,
+            full_name="Coach",
+            language="uk",
+            group_name="Wave",
+        )
+
+        updated = await service.get_profile(42)
+        assert updated is not None
+        assert updated.role == ROLE_TRAINER
+        assert updated.group_name == "Wave"
+        assert updated.language == "uk"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- add a dedicated onboarding FSM that guides new users through role, profile, group, and language selection on /start
- introduce a SQLite-backed user service and convert the legacy services module into a package to support profile storage
- wire the onboarding flow into the bot dispatcher, expose supporting keyboards, and cover the new logic with tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddb96367488325b8e0c5baa7ca58ad