### PR TITLE
Add sprint image summary generation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,6 +21,7 @@ from handlers.messages import router as messages_router
 from handlers.notifications import router as notifications_router
 from handlers.onboarding import router as onboarding_router
 from handlers.progress import router as progress_router
+from handlers.reports import router as reports_router
 from handlers.registration import router as registration_router
 from handlers.results import router as results_router
 from handlers.sprint_actions import router as sprint_router
@@ -96,6 +97,7 @@ def setup_dispatcher(
     dp.include_router(add_wizard_router)
     dp.include_router(admin_router)
     dp.include_router(progress_router)
+    dp.include_router(reports_router)
     dp.include_router(results_router)
     dp.include_router(sprint_router)
     dp.include_router(templates_router)

--- a/handlers/reports.py
+++ b/handlers/reports.py
@@ -1,0 +1,233 @@
+"""Handlers for generating graphical sprint reports."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+from aiogram import Router, types
+from aiogram.enums import MessageEntityType
+from aiogram.filters import Command
+from aiogram.types import BufferedInputFile, Message
+
+from reports import AttemptReport, SegmentReportRow, generate_image_report
+from role_service import RoleService
+from services import ws_pr, ws_results
+from utils import get_segments
+
+router = Router()
+
+
+@dataclass(frozen=True)
+class ResultPayload:
+    """Parsed representation of a sprint attempt."""
+
+    athlete_id: int
+    athlete_name: str
+    stroke: str
+    distance: int
+    timestamp: str
+    splits: Sequence[float]
+    total: float
+
+
+def _resolve_target_id(message: Message) -> tuple[int, str | None]:
+    """Extract target athlete id from command message."""
+
+    entities = message.entities or []
+    for entity in entities:
+        if entity.type is MessageEntityType.TEXT_MENTION and entity.user:
+            return entity.user.id, None
+    parts = (message.text or "").split(maxsplit=1)
+    if len(parts) == 1:
+        return message.from_user.id, None
+    arg = parts[1].strip()
+    if not arg:
+        return message.from_user.id, None
+    if arg.startswith("@"):
+        return message.from_user.id, "Не вдалося визначити користувача за нікнеймом."
+    try:
+        return int(arg), None
+    except ValueError:
+        return message.from_user.id, "Ідентифікатор спортсмена має бути числом."
+
+
+def _parse_row(row: Sequence[str]) -> ResultPayload | None:
+    """Parse worksheet row into a :class:`ResultPayload`."""
+
+    if not row or len(row) < 7:
+        return None
+    try:
+        athlete_id = int(row[0])
+        athlete_name = row[1]
+        stroke = str(row[2])
+        distance = int(row[3])
+        timestamp = str(row[4])
+        splits_raw = row[5]
+        total_raw = row[6]
+    except (ValueError, TypeError, IndexError):
+        return None
+    try:
+        splits = json.loads(splits_raw) if splits_raw else []
+    except json.JSONDecodeError:
+        return None
+    try:
+        splits = [float(str(value).replace(",", ".")) for value in splits]
+        total = float(str(total_raw).replace(",", "."))
+    except (TypeError, ValueError):
+        return None
+    return ResultPayload(
+        athlete_id=athlete_id,
+        athlete_name=athlete_name,
+        stroke=stroke,
+        distance=distance,
+        timestamp=timestamp,
+        splits=splits,
+        total=total,
+    )
+
+
+def _load_last_result(athlete_id: int) -> ResultPayload | None:
+    """Return latest attempt for the athlete."""
+
+    try:
+        rows = ws_results.get_all_values()
+    except Exception as exc:  # pragma: no cover - network dependent
+        logging.error("Failed to load results: %s", exc, exc_info=True)
+        return None
+    latest: ResultPayload | None = None
+    for row in rows[1:]:
+        payload = _parse_row(row)
+        if payload is None or payload.athlete_id != athlete_id:
+            continue
+        if latest is None or payload.timestamp > latest.timestamp:
+            latest = payload
+    return latest
+
+
+def _load_best_total(athlete_id: int, stroke: str, distance: int) -> float | None:
+    """Return best total time for an athlete stroke/distance pair."""
+
+    try:
+        rows = ws_results.get_all_values()
+    except Exception as exc:  # pragma: no cover - network dependent
+        logging.error("Failed to load totals: %s", exc, exc_info=True)
+        return None
+    best: float | None = None
+    for row in rows[1:]:
+        payload = _parse_row(row)
+        if payload is None:
+            continue
+        if (
+            payload.athlete_id != athlete_id
+            or payload.stroke != stroke
+            or payload.distance != distance
+        ):
+            continue
+        if best is None or payload.total < best:
+            best = payload.total
+    return best
+
+
+def _load_segment_bests(
+    athlete_id: int, stroke: str, distance: int, segments_count: int
+) -> list[tuple[float | None, str | None]]:
+    """Return best split per segment together with their timestamps."""
+
+    try:
+        rows = ws_pr.get_all_values()
+    except Exception as exc:  # pragma: no cover - network dependent
+        logging.error("Failed to load segment PRs: %s", exc, exc_info=True)
+        return [(None, None)] * segments_count
+    values: dict[int, tuple[float, str | None]] = {}
+    for row in rows:
+        if not row or len(row) < 2:
+            continue
+        key = row[0]
+        try:
+            uid_str, stroke_key, dist_str, seg_idx_str = key.split("|")
+            uid = int(uid_str)
+            seg_idx = int(seg_idx_str)
+            dist_val = int(dist_str)
+        except (ValueError, AttributeError):
+            continue
+        if uid != athlete_id or stroke_key != stroke or dist_val != distance:
+            continue
+        try:
+            value = float(str(row[1]).replace(",", "."))
+        except (TypeError, ValueError):
+            continue
+        timestamp = str(row[2]) if len(row) > 2 and row[2] else None
+        values[seg_idx] = (value, timestamp)
+    result: list[tuple[float | None, str | None]] = []
+    for idx in range(segments_count):
+        result.append(values.get(idx, (None, None)))
+    return result
+
+
+def _resolve_segment_lengths(distance: int, segments_count: int) -> Sequence[float]:
+    """Return best-guess segment lengths for report visualisation."""
+
+    if segments_count <= 0:
+        return []
+    defaults = [float(seg) for seg in get_segments(distance)]
+    if len(defaults) == segments_count:
+        return defaults
+    average = distance / segments_count if distance else 0
+    return [float(average)] * segments_count
+
+
+@router.message(Command("report_last"))
+async def cmd_report_last(message: types.Message, role_service: RoleService) -> None:
+    """Generate image summary for the latest attempt."""
+
+    target_id, error = _resolve_target_id(message)
+    if error:
+        await message.answer(error)
+        return
+    if not await role_service.can_access_athlete(message.from_user.id, target_id):
+        await message.answer("У вас немає доступу до цього спортсмена.")
+        return
+
+    payload = _load_last_result(target_id)
+    if payload is None:
+        await message.answer("Для спортсмена ще немає зафіксованих результатів.")
+        return
+
+    lengths = _resolve_segment_lengths(payload.distance, len(payload.splits))
+    segment_bests = _load_segment_bests(
+        payload.athlete_id, payload.stroke, payload.distance, len(payload.splits)
+    )
+    rows: list[SegmentReportRow] = []
+    for idx, split in enumerate(payload.splits):
+        distance = lengths[idx] if idx < len(lengths) else lengths[-1] if lengths else 0
+        best_value = segment_bests[idx][0] if idx < len(segment_bests) else None
+        rows.append(SegmentReportRow(time=split, distance=distance, best=best_value))
+
+    sob_flag = any(
+        ts and ts == payload.timestamp for _, ts in segment_bests[: len(payload.splits)]
+    )
+    best_total = _load_best_total(payload.athlete_id, payload.stroke, payload.distance)
+    total_flag = best_total is not None and abs(payload.total - best_total) <= 1e-6
+
+    attempt = AttemptReport(
+        athlete_name=payload.athlete_name or f"ID {payload.athlete_id}",
+        stroke=payload.stroke,
+        distance=payload.distance,
+        timestamp=payload.timestamp,
+        total_time=payload.total,
+        segments=rows,
+        total_is_pr=total_flag,
+        sob_improved=sob_flag,
+    )
+    try:
+        image_bytes = generate_image_report(attempt)
+    except ValueError:
+        await message.answer("Не вдалося згенерувати звіт для порожнього результату.")
+        return
+
+    file = BufferedInputFile(image_bytes, filename="report.png")
+    caption = f"Остання спроба: {payload.distance} м, {payload.stroke}."
+    await message.answer_photo(file, caption=caption)

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,0 +1,9 @@
+"""Report generation utilities."""
+
+from .image_report import AttemptReport, SegmentReportRow, generate_image_report
+
+__all__ = [
+    "AttemptReport",
+    "SegmentReportRow",
+    "generate_image_report",
+]

--- a/reports/image_report.py
+++ b/reports/image_report.py
@@ -1,0 +1,184 @@
+"""Image-based sprint report generator."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")
+from matplotlib import pyplot as plt
+
+from utils import fmt_time, speed
+
+
+@dataclass(frozen=True)
+class SegmentReportRow:
+    """Single table row describing segment performance."""
+
+    time: float
+    distance: float
+    best: float | None = None
+
+    @property
+    def velocity(self) -> float:
+        """Return segment speed in metres per second."""
+
+        return speed(self.distance, self.time)
+
+    @property
+    def percent_to_best(self) -> float | None:
+        """Return percentage difference to the best split (positive is slower)."""
+
+        if self.best is None or self.best <= 0:
+            return None
+        return (self.time / self.best - 1) * 100
+
+    @property
+    def pace(self) -> float:
+        """Return pace in seconds per 100 metres."""
+
+        if not self.distance:
+            return 0.0
+        return self.time / self.distance * 100
+
+
+@dataclass(frozen=True)
+class AttemptReport:
+    """Metadata required to render the sprint image report."""
+
+    athlete_name: str
+    stroke: str
+    distance: int
+    timestamp: str
+    total_time: float
+    segments: Sequence[SegmentReportRow]
+    total_is_pr: bool = False
+    sob_improved: bool = False
+
+    def pace_values(self) -> list[float]:
+        """Return pace values for plotting."""
+
+        return [segment.pace for segment in self.segments]
+
+
+_TITLE_COLOR = "#1f2937"
+_TABLE_HEADER_COLOR = "#e5e7eb"
+_TABLE_CELL_COLOR = "#f9fafb"
+_CHART_COLOR = "#2563eb"
+_GRID_COLOR = "#d1d5db"
+_FOOTER_COLOR = "#4b5563"
+_BACKGROUND_COLOR = "#ffffff"
+
+
+def _format_percent(value: float | None) -> str:
+    if value is None:
+        return "—"
+    if value >= 0:
+        return f"+{value:.1f}%"
+    return f"{value:.1f}%"
+
+
+def _build_table(ax: plt.Axes, segments: Sequence[SegmentReportRow]) -> None:
+    ax.axis("off")
+    headers = ["№", "Час", "Швидкість (м/с)", "% до найкращого"]
+    cell_data: list[list[str]] = []
+    for idx, segment in enumerate(segments, start=1):
+        cell_data.append(
+            [
+                str(idx),
+                fmt_time(segment.time),
+                f"{segment.velocity:.2f}",
+                _format_percent(segment.percent_to_best),
+            ]
+        )
+    table = ax.table(
+        cellText=cell_data,
+        colLabels=headers,
+        cellLoc="center",
+        loc="upper left",
+        colColours=[_TABLE_HEADER_COLOR] * len(headers),
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(10)
+    table.scale(1, 1.6)
+    for (row, col), cell in table.get_celld().items():
+        cell.set_edgecolor("white")
+        if row == 0:
+            cell.set_text_props(weight="bold", color=_TITLE_COLOR)
+        else:
+            cell.set_facecolor(_TABLE_CELL_COLOR)
+
+
+def _build_chart(ax: plt.Axes, segments: Sequence[SegmentReportRow]) -> None:
+    x_values = list(range(1, len(segments) + 1))
+    y_values = [segment.pace for segment in segments]
+    ax.plot(
+        x_values,
+        y_values,
+        color=_CHART_COLOR,
+        marker="o",
+        linewidth=2,
+    )
+    ax.set_xlabel("Сегмент")
+    ax.set_ylabel("Темп (сек/100м)")
+    ax.grid(True, color=_GRID_COLOR, linewidth=0.8, linestyle="--", alpha=0.6)
+    ax.set_xlim(0.8, len(segments) + 0.2)
+
+
+def _build_footer(ax: plt.Axes, payload: AttemptReport) -> None:
+    ax.axis("off")
+    footer_lines = [
+        f"{payload.timestamp} — {payload.athlete_name}",
+        f"{payload.stroke}, {payload.distance} м",
+        "Загальний час: {time} | PR: {pr} | SoB: {sob}".format(
+            time=fmt_time(payload.total_time),
+            pr="так" if payload.total_is_pr else "—",
+            sob="так" if payload.sob_improved else "—",
+        ),
+    ]
+    ax.text(
+        0.0,
+        0.7,
+        "\n".join(footer_lines),
+        fontsize=11,
+        color=_FOOTER_COLOR,
+        va="top",
+    )
+
+
+def generate_image_report(payload: AttemptReport) -> bytes:
+    """Render sprint report as PNG bytes."""
+
+    if not payload.segments:
+        raise ValueError("At least one segment is required to build the report")
+
+    fig = plt.figure(figsize=(8, 6), dpi=100, facecolor=_BACKGROUND_COLOR)
+    grid = fig.add_gridspec(3, 1, height_ratios=[1.4, 1.4, 0.6])
+
+    table_ax = fig.add_subplot(grid[0])
+    chart_ax = fig.add_subplot(grid[1])
+    footer_ax = fig.add_subplot(grid[2])
+
+    fig.suptitle(
+        f"Спринт: {payload.stroke} • {payload.distance} м",
+        fontsize=16,
+        color=_TITLE_COLOR,
+        fontweight="bold",
+        x=0.02,
+        ha="left",
+    )
+
+    _build_table(table_ax, payload.segments)
+    _build_chart(chart_ax, payload.segments)
+    _build_footer(footer_ax, payload)
+
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png", dpi=100, bbox_inches="tight", facecolor=_BACKGROUND_COLOR)
+    plt.close(fig)
+    buffer.seek(0)
+    return buffer.getvalue()

--- a/tests/test_image_report.py
+++ b/tests/test_image_report.py
@@ -1,0 +1,35 @@
+"""Snapshot tests for sprint image report generation."""
+
+from __future__ import annotations
+
+import hashlib
+
+from reports import AttemptReport, SegmentReportRow, generate_image_report
+
+
+def test_generate_image_report_snapshot() -> None:
+    """Generated image should remain stable across runs."""
+
+    segments = [
+        SegmentReportRow(time=12.45, distance=25.0, best=12.3),
+        SegmentReportRow(time=12.80, distance=25.0, best=12.5),
+        SegmentReportRow(time=13.10, distance=25.0, best=12.9),
+        SegmentReportRow(time=13.50, distance=25.0, best=13.2),
+    ]
+    attempt = AttemptReport(
+        athlete_name="Test Athlete",
+        stroke="freestyle",
+        distance=100,
+        timestamp="2024-04-05 10:00:00",
+        total_time=sum(segment.time for segment in segments),
+        segments=segments,
+        total_is_pr=True,
+        sob_improved=True,
+    )
+
+    image_bytes = generate_image_report(attempt)
+
+    assert len(image_bytes) < 150_000
+
+    digest = hashlib.sha256(image_bytes).hexdigest()
+    assert digest == "3924eb08b4a343051deba5e18c842ca9984ffbbdf6fcd78443db93505ca5d677"


### PR DESCRIPTION
## Summary
- add a matplotlib-based report builder that renders split tables and pace charts as PNG
- expose a /report_last command that gathers the latest attempt data and sends the generated image
- cover the generator with a snapshot test and register the new router in the dispatcher

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddbff44578832583bcf8df8df7528e