### PR TITLE
Add search command with filtered result pagination

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -22,6 +22,7 @@ from handlers.notifications import router as notifications_router
 from handlers.onboarding import router as onboarding_router
 from handlers.progress import router as progress_router
 from handlers.reports import router as reports_router
+from handlers.search import router as search_router
 from handlers.registration import router as registration_router
 from handlers.results import router as results_router
 from handlers.sprint_actions import router as sprint_router
@@ -30,6 +31,7 @@ from middlewares.roles import RoleMiddleware
 from notifications import NotificationService
 from role_service import RoleService
 from services import ADMIN_IDS, bot
+from services.query_service import QueryService
 from services.user_service import UserService
 from template_service import TemplateService
 
@@ -98,6 +100,7 @@ def setup_dispatcher(
     dp.include_router(admin_router)
     dp.include_router(progress_router)
     dp.include_router(reports_router)
+    dp.include_router(search_router)
     dp.include_router(results_router)
     dp.include_router(sprint_router)
     dp.include_router(templates_router)
@@ -125,6 +128,8 @@ async def main() -> None:
     await user_service.init()
     template_service = TemplateService()
     await template_service.init()
+    query_service = QueryService()
+    await query_service.init()
     backup_service = BackupService(
         bot=bot,
         db_path=Path(os.getenv("CHAT_DB_PATH", DB_PATH)),
@@ -145,6 +150,7 @@ async def main() -> None:
         role_service=role_service,
         user_service=user_service,
         template_service=template_service,
+        query_service=query_service,
     )
 
 

--- a/handlers/search.py
+++ b/handlers/search.py
@@ -1,0 +1,361 @@
+"""Handlers implementing sprint result search with filters."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Mapping, Sequence
+
+from aiogram import F, Router, types
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+
+from keyboards import (
+    SearchFilterCB,
+    SearchPageCB,
+    build_search_athlete_keyboard,
+    build_search_distance_keyboard,
+    build_search_pr_keyboard,
+    build_search_results_keyboard,
+    build_search_style_keyboard,
+)
+from role_service import RoleService, ROLE_ATHLETE
+from services.query_service import QueryService, SearchFilters, SearchPage
+from utils import fmt_time
+
+router = Router()
+
+PAGE_SIZE = 5
+
+STYLE_CHOICES: Sequence[tuple[str, str]] = (
+    ("any", "Будь-який стиль"),
+    ("freestyle", "🏊‍♂️ Кроль"),
+    ("backstroke", "🏊‍♀️ Спина"),
+    ("butterfly", "🦋 Батерфляй"),
+    ("breaststroke", "🐸 Брас"),
+    ("medley", "🔁 Комплекс"),
+)
+
+STROKE_LABELS = {value: label for value, label in STYLE_CHOICES if value != "any"}
+
+DISTANCE_CHOICES: Sequence[tuple[str, str]] = (
+    ("any", "Будь-яка дистанція"),
+    ("50", "50 м"),
+    ("100", "100 м"),
+    ("200", "200 м"),
+    ("400", "400 м"),
+    ("800", "800 м"),
+    ("1500", "1500 м"),
+)
+
+SKIP_TOKENS = {"-", "skip", "any", "пропустити", "пропустить", "будь-яка"}
+
+
+class SearchStates(StatesGroup):
+    """FSM states for search wizard."""
+
+    choose_athlete = State()
+    choose_style = State()
+    choose_distance = State()
+    enter_dates = State()
+    choose_pr = State()
+    browsing = State()
+
+
+@router.message(Command("search"))
+async def start_search(
+    message: types.Message, state: FSMContext, role_service: RoleService
+) -> None:
+    """Initiate search wizard by asking for an athlete."""
+
+    await state.clear()
+    requester = message.from_user.id
+    accessible = set(await role_service.get_accessible_athletes(requester))
+    if not accessible:
+        accessible.add(requester)
+
+    users = await role_service.list_users(roles=(ROLE_ATHLETE,))
+    labels = {
+        str(user.telegram_id): user.full_name or f"ID {user.telegram_id}"
+        for user in users
+    }
+    options: list[tuple[str, str]] = []
+    for uid in sorted(accessible):
+        key = str(uid)
+        options.append((key, labels.get(key, f"ID {uid}")))
+
+    if not options:
+        key = str(requester)
+        options = [(key, labels.get(key, f"ID {requester}"))]
+
+    include_all = len(options) > 1
+    keyboard = build_search_athlete_keyboard(options, include_all=include_all)
+
+    await state.update_data(
+        athlete_id=None,
+        athlete_label="Усі спортсмени" if include_all else options[0][1],
+        athlete_labels={value: label for value, label in options},
+        stroke=None,
+        stroke_label="Будь-який стиль",
+        distance=None,
+        distance_label="Будь-яка дистанція",
+        date_from=None,
+        date_to=None,
+        date_label="Без обмежень",
+        only_pr=False,
+    )
+
+    await message.answer(
+        "Оберіть спортсмена для пошуку результатів.", reply_markup=keyboard
+    )
+    await state.set_state(SearchStates.choose_athlete)
+
+
+@router.callback_query(
+    SearchStates.choose_athlete, SearchFilterCB.filter(F.field == "athlete")
+)
+async def select_athlete(
+    callback: types.CallbackQuery, state: FSMContext, callback_data: SearchFilterCB
+) -> None:
+    """Handle athlete selection and proceed to style choice."""
+
+    await callback.answer()
+    data = await state.get_data()
+    raw_labels = data.get("athlete_labels")
+    labels: dict[str, str]
+    if isinstance(raw_labels, Mapping):
+        labels = {str(key): str(value) for key, value in raw_labels.items()}
+    else:
+        labels = {}
+    value = callback_data.value
+    if value == "any":
+        athlete_id: int | None = None
+        label = "Усі спортсмени"
+    else:
+        try:
+            athlete_id = int(value)
+        except ValueError:
+            athlete_id = None
+        label = labels.get(value, f"ID {value}")
+
+    await state.update_data(athlete_id=athlete_id, athlete_label=label)
+    await callback.message.answer(
+        "Оберіть стиль плавання:",
+        reply_markup=build_search_style_keyboard(STYLE_CHOICES),
+    )
+    await state.set_state(SearchStates.choose_style)
+
+
+@router.callback_query(
+    SearchStates.choose_style, SearchFilterCB.filter(F.field == "stroke")
+)
+async def select_style(
+    callback: types.CallbackQuery, state: FSMContext, callback_data: SearchFilterCB
+) -> None:
+    """Handle swim style selection."""
+
+    await callback.answer()
+    value = callback_data.value
+    if value == "any":
+        stroke = None
+        label = "Будь-який стиль"
+    else:
+        stroke = value
+        label = STROKE_LABELS.get(value, value)
+
+    await state.update_data(stroke=stroke, stroke_label=label)
+    await callback.message.answer(
+        "Оберіть дистанцію:",
+        reply_markup=build_search_distance_keyboard(DISTANCE_CHOICES),
+    )
+    await state.set_state(SearchStates.choose_distance)
+
+
+@router.callback_query(
+    SearchStates.choose_distance, SearchFilterCB.filter(F.field == "distance")
+)
+async def select_distance(
+    callback: types.CallbackQuery, state: FSMContext, callback_data: SearchFilterCB
+) -> None:
+    """Handle distance selection."""
+
+    await callback.answer()
+    value = callback_data.value
+    if value == "any":
+        distance = None
+        label = "Будь-яка дистанція"
+    else:
+        try:
+            distance = int(value)
+        except ValueError:
+            distance = None
+        label = f"{distance} м" if distance else "Будь-яка дистанція"
+
+    await state.update_data(distance=distance, distance_label=label)
+    await callback.message.answer(
+        "Введіть діапазон дат у форматі YYYY-MM-DD YYYY-MM-DD або '-' щоб пропустити.",
+    )
+    await state.set_state(SearchStates.enter_dates)
+
+
+@router.message(SearchStates.enter_dates)
+async def input_dates(message: types.Message, state: FSMContext) -> None:
+    """Parse date range input and proceed to PR filter."""
+
+    text = (message.text or "").strip()
+    try:
+        date_from, date_to, label = _parse_date_range(text)
+    except ValueError:
+        await message.answer(
+            "Не вдалося розпізнати діапазон. Використайте формат YYYY-MM-DD YYYY-MM-DD або '-'."
+        )
+        return
+
+    await state.update_data(date_from=date_from, date_to=date_to, date_label=label)
+    await message.answer(
+        "Показувати лише особисті рекорди?",
+        reply_markup=build_search_pr_keyboard(),
+    )
+    await state.set_state(SearchStates.choose_pr)
+
+
+@router.callback_query(SearchStates.choose_pr, SearchFilterCB.filter(F.field == "pr"))
+async def select_pr(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+    callback_data: SearchFilterCB,
+    query_service: QueryService,
+) -> None:
+    """Handle PR filter selection and show first page of results."""
+
+    await callback.answer()
+    value = callback_data.value
+    only_pr = value == "only"
+    await state.update_data(only_pr=only_pr)
+
+    data = await state.get_data()
+    filters = _filters_from_state(data)
+    page = await query_service.search_results(filters, page=1, page_size=PAGE_SIZE)
+    if page.total == 0:
+        await callback.message.answer("За заданими фільтрами нічого не знайдено.")
+        await state.set_state(SearchStates.browsing)
+        return
+
+    text = _format_results(page, data)
+    markup = build_search_results_keyboard(
+        page.items,
+        page=page.page,
+        total_pages=page.pages,
+        start_index=(page.page - 1) * PAGE_SIZE,
+    )
+    await callback.message.answer(text, reply_markup=markup)
+    await state.update_data(last_page=page.page, total_pages=page.pages)
+    await state.set_state(SearchStates.browsing)
+
+
+@router.callback_query(SearchStates.browsing, SearchPageCB.filter())
+async def paginate(
+    callback: types.CallbackQuery,
+    state: FSMContext,
+    callback_data: SearchPageCB,
+    query_service: QueryService,
+) -> None:
+    """Switch between result pages."""
+
+    await callback.answer()
+    target_page = max(1, callback_data.page)
+    data = await state.get_data()
+    filters = _filters_from_state(data)
+    page = await query_service.search_results(
+        filters, page=target_page, page_size=PAGE_SIZE
+    )
+    if page.total == 0:
+        await callback.message.edit_text("За заданими фільтрами нічого не знайдено.")
+        return
+
+    text = _format_results(page, data)
+    markup = build_search_results_keyboard(
+        page.items,
+        page=page.page,
+        total_pages=page.pages,
+        start_index=(page.page - 1) * PAGE_SIZE,
+    )
+    await callback.message.edit_text(text, reply_markup=markup)
+    await state.update_data(last_page=page.page, total_pages=page.pages)
+
+
+def _parse_date_token(raw: str) -> date:
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError(f"Некоректна дата: {raw!r}") from exc
+
+
+def _parse_date_range(value: str) -> tuple[str | None, str | None, str]:
+    if not value or value.lower() in SKIP_TOKENS:
+        return None, None, "Без обмежень"
+    parts = [part for part in value.replace(",", " ").split() if part]
+    if not parts:
+        return None, None, "Без обмежень"
+    if len(parts) == 1:
+        start = _parse_date_token(parts[0])
+        return start.isoformat(), start.isoformat(), start.strftime("%d.%m.%Y")
+    start = _parse_date_token(parts[0])
+    end = _parse_date_token(parts[1])
+    if end < start:
+        start, end = end, start
+    label = f"{start:%d.%m.%Y} – {end:%d.%m.%Y}"
+    return start.isoformat(), end.isoformat(), label
+
+
+def _filters_from_state(data: Mapping[str, Any]) -> SearchFilters:
+    raw_from = data.get("date_from")
+    raw_to = data.get("date_to")
+    date_from = date.fromisoformat(raw_from) if isinstance(raw_from, str) and raw_from else None
+    date_to = date.fromisoformat(raw_to) if isinstance(raw_to, str) and raw_to else None
+    athlete_id = data.get("athlete_id")
+    distance = data.get("distance")
+    stroke = data.get("stroke")
+    only_pr = bool(data.get("only_pr"))
+    return SearchFilters(
+        athlete_id=athlete_id if isinstance(athlete_id, int) else None,
+        stroke=stroke if isinstance(stroke, str) else None,
+        distance=distance if isinstance(distance, int) else None,
+        date_from=date_from,
+        date_to=date_to,
+        only_pr=only_pr,
+    )
+
+
+def _filters_summary(data: Mapping[str, Any]) -> str:
+    entries = [
+        f"Спортсмен: {data.get('athlete_label', 'Усі спортсмени')}",
+        f"Стиль: {data.get('stroke_label', 'Будь-який стиль')}",
+        f"Дистанція: {data.get('distance_label', 'Будь-яка дистанція')}",
+        f"Дати: {data.get('date_label', 'Без обмежень')}",
+        "PR: лише рекорди" if data.get("only_pr") else "PR: усі результати",
+    ]
+    return "Фільтри: " + "; ".join(entries)
+
+
+def _format_results(page: SearchPage, data: Mapping[str, Any]) -> str:
+    parts = ["🔎 Результати пошуку", _filters_summary(data)]
+    parts.append(f"Сторінка {page.page} з {max(page.pages, 1)}")
+    start_index = (page.page - 1) * PAGE_SIZE
+    for idx, item in enumerate(page.items, start=start_index + 1):
+        style_label = STROKE_LABELS.get(item.stroke, item.stroke)
+        athlete_name = item.athlete_name or f"ID {item.athlete_id}"
+        timestamp = item.timestamp.strftime("%d.%m.%Y %H:%M")
+        pr_flag = " • PR" if item.is_pr else ""
+        card = "\n".join(
+            [
+                f"{idx}. {timestamp} • {item.distance} м • {style_label}",
+                f"   👤 {athlete_name} ({item.athlete_id})",
+                f"   ⏱ {fmt_time(item.total_seconds)}{pr_flag}",
+            ]
+        )
+        parts.append(card)
+    return "\n\n".join(parts)
+
+
+__all__ = ["router", "SearchStates", "start_search"]

--- a/services/query_service.py
+++ b/services/query_service.py
@@ -1,0 +1,205 @@
+"""Utilities for searching stored sprint results."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True, slots=True)
+class SearchFilters:
+    """Query parameters supplied by the search wizard."""
+
+    athlete_id: int | None = None
+    stroke: str | None = None
+    distance: int | None = None
+    date_from: date | None = None
+    date_to: date | None = None
+    only_pr: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class SearchResult:
+    """Single sprint result matched by the query."""
+
+    result_id: int
+    athlete_id: int
+    athlete_name: str
+    stroke: str
+    distance: int
+    total_seconds: float
+    timestamp: datetime
+    is_pr: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SearchPage:
+    """Paginated collection of search results."""
+
+    items: tuple[SearchResult, ...]
+    total: int
+    page: int
+    pages: int
+
+
+class QueryService:
+    """Read sprint results with flexible filters."""
+
+    def __init__(self, db_path: Path | str = Path("data/results.db")) -> None:
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    async def init(self) -> None:
+        """Ensure SQLite schema exists."""
+
+        async with self._lock:
+            await asyncio.to_thread(self._ensure_schema)
+
+    async def search_results(
+        self,
+        filters: SearchFilters,
+        *,
+        page: int = 1,
+        page_size: int = 5,
+    ) -> SearchPage:
+        """Return paginated results for provided filters."""
+
+        if page_size <= 0:
+            raise ValueError("page_size must be positive")
+        if page <= 0:
+            page = 1
+        base_sql, args = self._build_where_clause(filters)
+        total = await asyncio.to_thread(self._count_results, base_sql, args)
+        if total == 0:
+            return SearchPage(items=(), total=0, page=1, pages=0)
+        pages = (total + page_size - 1) // page_size
+        if page > pages:
+            page = pages
+        offset = (page - 1) * page_size
+        rows = await asyncio.to_thread(
+            self._fetch_rows, base_sql, args, page_size, offset
+        )
+        return SearchPage(items=tuple(rows), total=total, page=page, pages=pages)
+
+    # --- internal helpers -------------------------------------------------
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS results (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    athlete_id INTEGER NOT NULL,
+                    athlete_name TEXT NOT NULL DEFAULT '',
+                    stroke TEXT NOT NULL,
+                    distance INTEGER NOT NULL,
+                    total_seconds REAL NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    is_pr INTEGER NOT NULL DEFAULT 0
+                );
+                CREATE INDEX IF NOT EXISTS idx_results_timestamp
+                    ON results(timestamp DESC);
+                CREATE INDEX IF NOT EXISTS idx_results_athlete
+                    ON results(athlete_id);
+                CREATE INDEX IF NOT EXISTS idx_results_stroke
+                    ON results(stroke);
+                CREATE INDEX IF NOT EXISTS idx_results_distance
+                    ON results(distance);
+                """
+            )
+            conn.commit()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    @staticmethod
+    def _build_where_clause(
+        filters: SearchFilters,
+    ) -> tuple[str, tuple[object, ...]]:
+        clauses = ["FROM results WHERE 1 = 1"]
+        args: list[object] = []
+        if filters.athlete_id is not None:
+            clauses.append("AND athlete_id = ?")
+            args.append(filters.athlete_id)
+        if filters.stroke:
+            clauses.append("AND stroke = ?")
+            args.append(filters.stroke)
+        if filters.distance is not None:
+            clauses.append("AND distance = ?")
+            args.append(filters.distance)
+        if filters.date_from:
+            clauses.append("AND DATE(timestamp) >= DATE(?)")
+            args.append(filters.date_from.isoformat())
+        if filters.date_to:
+            clauses.append("AND DATE(timestamp) <= DATE(?)")
+            args.append(filters.date_to.isoformat())
+        if filters.only_pr:
+            clauses.append("AND is_pr = 1")
+        sql = " ".join(clauses)
+        return sql, tuple(args)
+
+    def _count_results(self, base_sql: str, args: Sequence[object]) -> int:
+        query = f"SELECT COUNT(*) {base_sql}"
+        with self._connect() as conn:
+            cur = conn.execute(query, args)
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+
+    def _fetch_rows(
+        self,
+        base_sql: str,
+        args: Sequence[object],
+        limit: int,
+        offset: int,
+    ) -> tuple[SearchResult, ...]:
+        query = (
+            "SELECT id, athlete_id, athlete_name, stroke, distance, "
+            "total_seconds, timestamp, is_pr "
+            f"{base_sql} ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?"
+        )
+        with self._connect() as conn:
+            cur = conn.execute(query, (*args, limit, offset))
+            rows = cur.fetchall()
+        results: list[SearchResult] = []
+        for row in rows:
+            timestamp = self._parse_timestamp(row["timestamp"])
+            results.append(
+                SearchResult(
+                    result_id=int(row["id"]),
+                    athlete_id=int(row["athlete_id"]),
+                    athlete_name=str(row["athlete_name"] or ""),
+                    stroke=str(row["stroke"]),
+                    distance=int(row["distance"]),
+                    total_seconds=float(row["total_seconds"]),
+                    timestamp=timestamp,
+                    is_pr=bool(row["is_pr"]),
+                )
+            )
+        return tuple(results)
+
+    @staticmethod
+    def _parse_timestamp(value: str | bytes | None) -> datetime:
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+        text = (value or "").strip()
+        if not text:
+            raise ValueError("timestamp column cannot be empty")
+        try:
+            return datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise ValueError(f"invalid timestamp format: {text!r}") from exc
+
+
+__all__ = [
+    "QueryService",
+    "SearchFilters",
+    "SearchPage",
+    "SearchResult",
+]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from datetime import date, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Sequence
+from unittest.mock import AsyncMock
+
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.base import StorageKey
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from handlers.search import (
+    SearchStates,
+    input_dates,
+    paginate,
+    select_athlete,
+    select_distance,
+    select_pr,
+    select_style,
+    start_search,
+)
+from keyboards import SearchFilterCB, SearchPageCB
+from services.query_service import QueryService, SearchFilters, SearchPage, SearchResult
+
+
+def _make_state() -> FSMContext:
+    storage = MemoryStorage()
+    key = StorageKey(bot_id=1, chat_id=99, user_id=99)
+    return FSMContext(storage=storage, key=key)
+
+
+def _seed_results(db_path: Path, rows: Sequence[tuple[int, str, str, int, float, str, bool]]) -> None:
+    with sqlite3.connect(db_path) as conn:
+        for athlete_id, name, stroke, distance, total, timestamp, is_pr in rows:
+            conn.execute(
+                """
+                INSERT INTO results (athlete_id, athlete_name, stroke, distance, total_seconds, timestamp, is_pr)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (athlete_id, name, stroke, distance, total, timestamp, int(is_pr)),
+            )
+        conn.commit()
+
+
+class DummyMessage:
+    def __init__(self, text: str = "", user_id: int = 99, chat_id: int = 42) -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=user_id)
+        self.chat = SimpleNamespace(id=chat_id)
+        self.answer = AsyncMock()
+        self.edit_text = AsyncMock()
+
+
+class DummyCallback:
+    def __init__(self, message: DummyMessage) -> None:
+        self.message = message
+        self.from_user = message.from_user
+        self.data = ""
+        self.answer = AsyncMock()
+
+
+class FakeRoleService:
+    def __init__(self) -> None:
+        self._users = (
+            SimpleNamespace(telegram_id=1, full_name="User One"),
+            SimpleNamespace(telegram_id=2, full_name="User Two"),
+        )
+
+    async def get_accessible_athletes(self, requester_id: int) -> Sequence[int]:
+        return (1, 2)
+
+    async def list_users(self, roles: Sequence[str] | None = None) -> Sequence[SimpleNamespace]:
+        return self._users
+
+
+class FakeQueryService:
+    def __init__(self, pages: dict[int, SearchPage]) -> None:
+        self._pages = pages
+        self.calls: list[tuple[SearchFilters, int, int]] = []
+
+    async def search_results(
+        self, filters: SearchFilters, *, page: int, page_size: int
+    ) -> SearchPage:
+        self.calls.append((filters, page, page_size))
+        if page in self._pages:
+            return self._pages[page]
+        return next(iter(self._pages.values()))
+
+
+def test_query_service_filters(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        db_path = tmp_path / "results.db"
+        service = QueryService(db_path)
+        await service.init()
+        _seed_results(
+            db_path,
+            [
+                (
+                    1,
+                    "User One",
+                    "freestyle",
+                    100,
+                    70.5,
+                    datetime(2024, 1, 10, 10, 0).isoformat(),
+                    True,
+                ),
+                (
+                    1,
+                    "User One",
+                    "freestyle",
+                    200,
+                    150.0,
+                    datetime(2024, 2, 5, 9, 0).isoformat(),
+                    False,
+                ),
+                (
+                    2,
+                    "User Two",
+                    "backstroke",
+                    100,
+                    72.0,
+                    datetime(2024, 1, 15, 11, 0).isoformat(),
+                    True,
+                ),
+            ],
+        )
+        filters = SearchFilters(
+            athlete_id=1,
+            stroke="freestyle",
+            distance=100,
+            date_from=date(2024, 1, 1),
+            date_to=date(2024, 1, 31),
+            only_pr=True,
+        )
+        page = await service.search_results(filters, page=1, page_size=5)
+        assert page.total == 1
+        assert len(page.items) == 1
+        result = page.items[0]
+        assert result.athlete_id == 1
+        assert result.is_pr is True
+        assert result.distance == 100
+
+    asyncio.run(scenario())
+
+
+def test_query_service_pagination(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        db_path = tmp_path / "results.db"
+        service = QueryService(db_path)
+        await service.init()
+        rows = [
+            (
+                1,
+                "User One",
+                "freestyle",
+                50,
+                30.0 + idx,
+                datetime(2024, 1, 1 + idx, 8, 0).isoformat(),
+                bool(idx % 2),
+            )
+            for idx in range(7)
+        ]
+        _seed_results(db_path, rows)
+        filters = SearchFilters(athlete_id=1)
+        page1 = await service.search_results(filters, page=1, page_size=5)
+        assert page1.total == 7
+        assert page1.pages == 2
+        assert len(page1.items) == 5
+        page2 = await service.search_results(filters, page=2, page_size=5)
+        assert page2.page == 2
+        assert len(page2.items) == 2
+        assert page2.items[0].timestamp >= page2.items[1].timestamp
+
+    asyncio.run(scenario())
+
+
+def test_search_wizard_flow() -> None:
+    async def scenario() -> None:
+        state = _make_state()
+        role_service = FakeRoleService()
+        pages = {
+            1: SearchPage(
+                items=(
+                    SearchResult(
+                        result_id=10,
+                        athlete_id=1,
+                        athlete_name="User One",
+                        stroke="freestyle",
+                        distance=100,
+                        total_seconds=70.5,
+                        timestamp=datetime(2024, 1, 10, 10, 0),
+                        is_pr=True,
+                    ),
+                    SearchResult(
+                        result_id=11,
+                        athlete_id=1,
+                        athlete_name="User One",
+                        stroke="freestyle",
+                        distance=100,
+                        total_seconds=71.2,
+                        timestamp=datetime(2024, 1, 5, 9, 0),
+                        is_pr=False,
+                    ),
+                ),
+                total=3,
+                page=1,
+                pages=2,
+            ),
+            2: SearchPage(
+                items=(
+                    SearchResult(
+                        result_id=12,
+                        athlete_id=1,
+                        athlete_name="User One",
+                        stroke="freestyle",
+                        distance=100,
+                        total_seconds=72.0,
+                        timestamp=datetime(2023, 12, 25, 18, 0),
+                        is_pr=False,
+                    ),
+                ),
+                total=3,
+                page=2,
+                pages=2,
+            ),
+        }
+        query_service = FakeQueryService(pages)
+
+        start_msg = DummyMessage(text="/search")
+        await start_search(start_msg, state, role_service)
+        assert await state.get_state() == SearchStates.choose_athlete.state
+        start_msg.answer.assert_called_once()
+
+        athlete_cb = DummyCallback(DummyMessage())
+        await select_athlete(
+            athlete_cb, state, SearchFilterCB(field="athlete", value="1")
+        )
+        assert await state.get_state() == SearchStates.choose_style.state
+        athlete_cb.answer.assert_awaited()
+
+        style_cb = DummyCallback(DummyMessage())
+        await select_style(
+            style_cb, state, SearchFilterCB(field="stroke", value="freestyle")
+        )
+        assert await state.get_state() == SearchStates.choose_distance.state
+        style_cb.answer.assert_awaited()
+
+        distance_cb = DummyCallback(DummyMessage())
+        await select_distance(
+            distance_cb, state, SearchFilterCB(field="distance", value="100")
+        )
+        assert await state.get_state() == SearchStates.enter_dates.state
+        distance_cb.answer.assert_awaited()
+
+        await input_dates(DummyMessage("2024-01-01 2024-02-01"), state)
+        assert await state.get_state() == SearchStates.choose_pr.state
+
+        pr_cb_message = DummyMessage()
+        pr_cb = DummyCallback(pr_cb_message)
+        await select_pr(
+            pr_cb, state, SearchFilterCB(field="pr", value="only"), query_service
+        )
+        assert await state.get_state() == SearchStates.browsing.state
+        pr_cb.answer.assert_awaited()
+        pr_cb_message.answer.assert_called_once()
+
+        filters, page_number, page_size = query_service.calls[0]
+        assert page_number == 1 and page_size == 5
+        assert filters.athlete_id == 1
+        assert filters.stroke == "freestyle"
+        assert filters.distance == 100
+        assert filters.only_pr is True
+
+        text = pr_cb_message.answer.await_args[0][0]
+        assert "Сторінка 1 з 2" in text
+        assert "PR" in text
+
+        markup = pr_cb_message.answer.await_args[1]["reply_markup"]
+        assert markup is not None
+        assert len(markup.inline_keyboard) >= 1
+
+        nav_cb = DummyCallback(DummyMessage())
+        await paginate(nav_cb, state, SearchPageCB(page=2), query_service)
+        assert query_service.calls[-1][1] == 2
+        nav_cb.answer.assert_awaited()
+        nav_cb.message.edit_text.assert_called_once()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- implement /search wizard with athlete, style, distance, date and PR filters plus paginated results cards
- add SQLite-backed QueryService for filtered result retrieval and expose pagination helpers in keyboards
- cover search flow and query service with pytest-based tests and register the router/service in the bot

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddc3ae5c14832584b6db83cad39db6