### PR TITLE
Add leaderboard and personal progress commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -17,6 +17,7 @@ from handlers.backup import router as backup_router
 from handlers.common import router as common_router
 from handlers.error_handler import router as error_router
 from handlers.menu import router as menu_router
+from handlers.leaderboard import router as leaderboard_router
 from handlers.messages import router as messages_router
 from handlers.notifications import router as notifications_router
 from handlers.onboarding import router as onboarding_router
@@ -32,6 +33,7 @@ from notifications import NotificationService
 from role_service import RoleService
 from services import ADMIN_IDS, bot
 from services.query_service import QueryService
+from services.stats_service import StatsService
 from services.user_service import UserService
 from template_service import TemplateService
 
@@ -99,6 +101,7 @@ def setup_dispatcher(
     dp.include_router(add_wizard_router)
     dp.include_router(admin_router)
     dp.include_router(progress_router)
+    dp.include_router(leaderboard_router)
     dp.include_router(reports_router)
     dp.include_router(search_router)
     dp.include_router(results_router)
@@ -130,6 +133,8 @@ async def main() -> None:
     await template_service.init()
     query_service = QueryService()
     await query_service.init()
+    stats_service = StatsService()
+    await stats_service.init()
     backup_service = BackupService(
         bot=bot,
         db_path=Path(os.getenv("CHAT_DB_PATH", DB_PATH)),
@@ -151,6 +156,7 @@ async def main() -> None:
         user_service=user_service,
         template_service=template_service,
         query_service=query_service,
+        stats_service=stats_service,
     )
 
 

--- a/handlers/leaderboard.py
+++ b/handlers/leaderboard.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from aiogram import Router, types
+from aiogram.filters import Command
+
+from services.stats_service import StatsPeriod, StatsService
+from utils import fmt_time
+
+router = Router()
+
+LEADERBOARD_LIMIT = 10
+
+PERIOD_TITLES = {
+    StatsPeriod.WEEK: "недели",
+    StatsPeriod.MONTH: "месяца",
+}
+
+STROKE_LABELS = {
+    "freestyle": "кроль",
+    "backstroke": "спина",
+    "butterfly": "батерфляй",
+    "breaststroke": "брас",
+    "medley": "комплекс",
+}
+
+
+def _parse_period(message: types.Message) -> StatsPeriod | None:
+    text = (message.text or "").strip()
+    parts = text.split(maxsplit=1)
+    if len(parts) < 2:
+        return None
+    raw = parts[1].strip().lower()
+    if raw == StatsPeriod.WEEK.value:
+        return StatsPeriod.WEEK
+    if raw == StatsPeriod.MONTH.value:
+        return StatsPeriod.MONTH
+    return None
+
+
+@router.message(Command("leaders"))
+async def show_leaders(message: types.Message, stats_service: StatsService) -> None:
+    period = _parse_period(message)
+    if period is None:
+        await message.answer("Используй: /leaders week или /leaders month")
+        return
+
+    progress_msg = await message.answer("⏳ Считаю рейтинг…")
+    entries = await stats_service.leaderboard(period, limit=LEADERBOARD_LIMIT)
+    if not entries:
+        await progress_msg.edit_text("Пока нет улучшений за выбранный период.")
+        return
+
+    title = PERIOD_TITLES.get(period, period.value)
+    lines = [f"🏆 Лидеры {title}:"]
+    for idx, entry in enumerate(entries, start=1):
+        lines.append(
+            f"{idx}. {entry.athlete_name} — {entry.pr_count} PR, {entry.attempts} попыток"
+        )
+    await progress_msg.edit_text("\n".join(lines))
+
+
+@router.message(Command("my_progress_week"))
+async def my_progress_week(message: types.Message, stats_service: StatsService) -> None:
+    user = message.from_user
+    if user is None:
+        await message.answer("Не удалось определить профиль пользователя.")
+        return
+
+    progress_msg = await message.answer("⏳ Сканирую твою неделю…")
+    summary = await stats_service.weekly_progress(user.id)
+    if summary.attempts == 0:
+        await progress_msg.edit_text("За 7 дней попыток не найдено. Пора в бассейн! 💪")
+        return
+
+    lines = [
+        "📊 Итоги недели:",
+        f"Попытки: {summary.attempts}",
+        f"PR: {summary.pr_count}",
+    ]
+
+    if summary.highlights:
+        lines.append("🔥 Лучшие заплывы:")
+        for result in summary.highlights:
+            prefix = "⭐" if result.is_pr else "•"
+            stroke_label = STROKE_LABELS.get(result.stroke, result.stroke)
+            lines.append(
+                f"{prefix} {result.distance} м {stroke_label} — {fmt_time(result.total_seconds)}"
+            )
+    else:
+        lines.append("Пока без выдающихся результатов.")
+
+    await progress_msg.edit_text("\n".join(lines))

--- a/services/stats_service.py
+++ b/services/stats_service.py
@@ -1,9 +1,20 @@
-"""Utilities for analysing sprint progress and personal records."""
+"""Utilities for analysing sprint progress and personal records.
+
+The leaderboard metric is the number of new personal records (PR) achieved
+within the requested period. This keeps the implementation lightweight and
+ensures the ranking can be computed directly from the stored attempts without
+reconstructing historical deltas.
+"""
 
 from __future__ import annotations
 
+import asyncio
+import sqlite3
 from dataclasses import dataclass
-from typing import Sequence
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Iterable, Sequence
 
 
 @dataclass(frozen=True)
@@ -23,6 +34,228 @@ class SobStats:
     previous: float | None
     current: float
     delta: float
+
+
+@dataclass(frozen=True, slots=True)
+class LeaderboardEntry:
+    """Single leaderboard row for a period."""
+
+    athlete_id: int
+    athlete_name: str
+    pr_count: int
+    attempts: int
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressResult:
+    """Highlight attempt used in personal progress summaries."""
+
+    stroke: str
+    distance: int
+    total_seconds: float
+    timestamp: datetime
+    is_pr: bool
+
+
+@dataclass(frozen=True, slots=True)
+class WeeklyProgress:
+    """Personal summary for the last week."""
+
+    athlete_id: int
+    attempts: int
+    pr_count: int
+    highlights: tuple[ProgressResult, ...]
+
+
+class StatsPeriod(str, Enum):
+    """Supported leaderboard periods."""
+
+    WEEK = "week"
+    MONTH = "month"
+
+
+class StatsService:
+    """Aggregate sprint statistics from SQLite storage."""
+
+    _SETUP_SQL = """
+    CREATE TABLE IF NOT EXISTS results (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        athlete_id INTEGER NOT NULL,
+        athlete_name TEXT NOT NULL DEFAULT '',
+        stroke TEXT NOT NULL,
+        distance INTEGER NOT NULL,
+        total_seconds REAL NOT NULL,
+        timestamp TEXT NOT NULL,
+        is_pr INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_stats_timestamp ON results(timestamp DESC);
+    CREATE INDEX IF NOT EXISTS idx_stats_athlete ON results(athlete_id);
+    """
+
+    def __init__(self, db_path: Path | str = Path("data/results.db")) -> None:
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    async def init(self) -> None:
+        """Ensure table required for stats exists."""
+
+        async with self._lock:
+            await asyncio.to_thread(self._ensure_schema)
+
+    async def leaderboard(
+        self,
+        period: StatsPeriod,
+        *,
+        limit: int = 10,
+        now: datetime | None = None,
+    ) -> tuple[LeaderboardEntry, ...]:
+        """Return leaderboard entries for the given period."""
+
+        since = self._period_start(period, now=now)
+        rows = await asyncio.to_thread(self._fetch_leaderboard, since, limit)
+        return tuple(rows)
+
+    async def weekly_progress(
+        self,
+        athlete_id: int,
+        *,
+        limit: int = 3,
+        now: datetime | None = None,
+    ) -> WeeklyProgress:
+        """Return attempts, PR count and highlights for the last 7 days."""
+
+        since = self._period_start(StatsPeriod.WEEK, now=now)
+        attempts_task = asyncio.create_task(
+            asyncio.to_thread(self._count_attempts, athlete_id, since)
+        )
+        prs_task = asyncio.create_task(
+            asyncio.to_thread(self._count_prs, athlete_id, since)
+        )
+        highlights_task = asyncio.create_task(
+            asyncio.to_thread(self._fetch_highlights, athlete_id, since, limit)
+        )
+        attempts, pr_count, highlights = await asyncio.gather(
+            attempts_task, prs_task, highlights_task
+        )
+        return WeeklyProgress(
+            athlete_id=athlete_id,
+            attempts=attempts,
+            pr_count=pr_count,
+            highlights=tuple(highlights),
+        )
+
+    # --- calculation helpers -------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(self._SETUP_SQL)
+            conn.commit()
+
+    @staticmethod
+    def _period_start(period: StatsPeriod, *, now: datetime | None) -> datetime:
+        current = now or datetime.now(timezone.utc)
+        if period is StatsPeriod.MONTH:
+            delta = timedelta(days=30)
+        else:
+            delta = timedelta(days=7)
+        return current - delta
+
+    def _fetch_leaderboard(
+        self, since: datetime, limit: int
+    ) -> Iterable[LeaderboardEntry]:
+        query = """
+            SELECT
+                athlete_id AS athlete_id,
+                COALESCE(NULLIF(TRIM(athlete_name), ''), 'ID ' || athlete_id) AS name,
+                SUM(CASE WHEN is_pr = 1 THEN 1 ELSE 0 END) AS pr_count,
+                COUNT(*) AS attempts
+            FROM results
+            WHERE timestamp >= ?
+            GROUP BY athlete_id
+            HAVING SUM(CASE WHEN is_pr = 1 THEN 1 ELSE 0 END) > 0
+            ORDER BY pr_count DESC, attempts DESC, name COLLATE NOCASE ASC
+            LIMIT ?
+        """
+        args = (since.isoformat(), limit)
+        with self._connect() as conn:
+            cursor = conn.execute(query, args)
+            rows = cursor.fetchall()
+        for row in rows:
+            yield LeaderboardEntry(
+                athlete_id=int(row["athlete_id"]),
+                athlete_name=str(row["name"] or f"ID {row['athlete_id']}").strip(),
+                pr_count=int(row["pr_count"] or 0),
+                attempts=int(row["attempts"] or 0),
+            )
+
+    def _count_attempts(self, athlete_id: int, since: datetime) -> int:
+        query = """
+            SELECT COUNT(*)
+            FROM results
+            WHERE athlete_id = ? AND timestamp >= ?
+        """
+        with self._connect() as conn:
+            cursor = conn.execute(query, (athlete_id, since.isoformat()))
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+
+    def _count_prs(self, athlete_id: int, since: datetime) -> int:
+        query = """
+            SELECT COUNT(*)
+            FROM results
+            WHERE athlete_id = ? AND timestamp >= ? AND is_pr = 1
+        """
+        with self._connect() as conn:
+            cursor = conn.execute(query, (athlete_id, since.isoformat()))
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+
+    def _fetch_highlights(
+        self, athlete_id: int, since: datetime, limit: int
+    ) -> Iterable[ProgressResult]:
+        query = """
+            SELECT stroke, distance, total_seconds, timestamp, is_pr
+            FROM results
+            WHERE athlete_id = ? AND timestamp >= ?
+            ORDER BY is_pr DESC, total_seconds ASC, timestamp DESC
+            LIMIT ?
+        """
+        args = (athlete_id, since.isoformat(), limit)
+        with self._connect() as conn:
+            cursor = conn.execute(query, args)
+            rows = cursor.fetchall()
+        results: list[ProgressResult] = []
+        for row in rows:
+            ts_raw = row["timestamp"]
+            timestamp = self._parse_timestamp(ts_raw)
+            results.append(
+                ProgressResult(
+                    stroke=str(row["stroke"]),
+                    distance=int(row["distance"]),
+                    total_seconds=float(row["total_seconds"]),
+                    timestamp=timestamp,
+                    is_pr=bool(row["is_pr"]),
+                )
+            )
+        return results
+
+    @staticmethod
+    def _parse_timestamp(raw: str | bytes | None) -> datetime:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        text = (raw or "").strip()
+        if not text:
+            raise ValueError("timestamp column cannot be empty")
+        try:
+            return datetime.fromisoformat(text)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"invalid timestamp format: {text!r}") from exc
 
 
 def calc_total_pr(previous_best: float | None, current_total: float) -> TotalPRResult:
@@ -81,3 +314,17 @@ def calc_sob(
     else:
         delta = max(previous - current_total, 0.0)
     return SobStats(previous=previous, current=current_total, delta=delta)
+
+
+__all__ = [
+    "LeaderboardEntry",
+    "ProgressResult",
+    "SobStats",
+    "StatsPeriod",
+    "StatsService",
+    "TotalPRResult",
+    "WeeklyProgress",
+    "calc_segment_prs",
+    "calc_sob",
+    "calc_total_pr",
+]

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from handlers.leaderboard import my_progress_week, show_leaders
+from services.stats_service import StatsService
+
+
+class DummySentMessage:
+    def __init__(self) -> None:
+        self.edit_text = AsyncMock()
+        self.payloads: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def _edit_text(self, *args: Any, **kwargs: Any) -> Any:
+        self.payloads.append((args, kwargs))
+        return None
+
+
+class DummyMessage:
+    def __init__(self, text: str, *, user_id: int = 1) -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=user_id)
+        self.sent: list[DummySentMessage] = []
+
+        async def _answer(*_args: Any, **_kwargs: Any) -> DummySentMessage:
+            sent = DummySentMessage()
+            self.sent.append(sent)
+            return sent
+
+        self.answer = AsyncMock(side_effect=_answer)
+
+
+def _seed_results(
+    db_path: Path,
+    rows: list[tuple[int, str, str, int, float, str, bool]],
+) -> None:
+    with sqlite3.connect(db_path) as conn:
+        for athlete_id, name, stroke, distance, total, timestamp, is_pr in rows:
+            conn.execute(
+                """
+                INSERT INTO results (
+                    athlete_id, athlete_name, stroke, distance, total_seconds, timestamp, is_pr
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (athlete_id, name, stroke, distance, total, timestamp, int(is_pr)),
+            )
+        conn.commit()
+
+
+def test_leaders_command_week(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        db_path = tmp_path / "results.db"
+        service = StatsService(db_path)
+        await service.init()
+        now = datetime.now(timezone.utc)
+        _seed_results(
+            db_path,
+            [
+                (
+                    1,
+                    "User One",
+                    "freestyle",
+                    100,
+                    70.5,
+                    (now - timedelta(days=2)).isoformat(),
+                    True,
+                ),
+                (
+                    1,
+                    "User One",
+                    "freestyle",
+                    50,
+                    31.0,
+                    (now - timedelta(days=1)).isoformat(),
+                    True,
+                ),
+                (
+                    1,
+                    "User One",
+                    "freestyle",
+                    100,
+                    72.0,
+                    (now - timedelta(days=1)).isoformat(),
+                    False,
+                ),
+                (
+                    2,
+                    "User Two",
+                    "backstroke",
+                    100,
+                    72.5,
+                    (now - timedelta(days=3)).isoformat(),
+                    True,
+                ),
+                (
+                    3,
+                    "User Three",
+                    "breaststroke",
+                    200,
+                    150.0,
+                    (now - timedelta(days=10)).isoformat(),
+                    True,
+                ),
+            ],
+        )
+
+        message = DummyMessage("/leaders week")
+        await show_leaders(message, stats_service=service)
+
+        assert message.answer.await_count == 1
+        assert len(message.sent) == 1
+        final_text = message.sent[0].edit_text.call_args[0][0]
+        assert final_text.startswith("🏆 Лидеры недели:")
+        assert "User One — 2 PR" in final_text
+        assert final_text.index("User One") < final_text.index("User Two")
+
+    asyncio.run(scenario())
+
+
+def test_my_progress_week_summary(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        db_path = tmp_path / "results.db"
+        service = StatsService(db_path)
+        await service.init()
+        now = datetime.now(timezone.utc)
+        _seed_results(
+            db_path,
+            [
+                (
+                    5,
+                    "Athlete",
+                    "freestyle",
+                    50,
+                    30.5,
+                    (now - timedelta(days=2)).isoformat(),
+                    True,
+                ),
+                (
+                    5,
+                    "Athlete",
+                    "backstroke",
+                    50,
+                    31.2,
+                    (now - timedelta(days=3)).isoformat(),
+                    False,
+                ),
+                (
+                    5,
+                    "Athlete",
+                    "freestyle",
+                    50,
+                    30.2,
+                    (now - timedelta(days=1)).isoformat(),
+                    True,
+                ),
+                (
+                    5,
+                    "Athlete",
+                    "freestyle",
+                    50,
+                    31.5,
+                    (now - timedelta(days=12)).isoformat(),
+                    False,
+                ),
+            ],
+        )
+
+        message = DummyMessage("/my_progress_week", user_id=5)
+        await my_progress_week(message, stats_service=service)
+
+        assert message.answer.await_count == 1
+        final_text = message.sent[0].edit_text.call_args[0][0]
+        assert "Попытки: 3" in final_text
+        assert "PR: 2" in final_text
+        assert "⭐ 50 м кроль" in final_text
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- add a stats service that aggregates leaderboard and weekly progress data based on PR counts
- expose /leaders and /my_progress_week handlers with concise feedback messages
- cover the new stats flows with pytest checks

## Testing
- pip install -r requirements.txt
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddc681aa148325a31eef6fb3015d08