### PR TITLE
Add audit logging with undo support

### DIFF
--- a/db/migrations/001_create_audit_log.sql
+++ b/db/migrations/001_create_audit_log.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    before_json TEXT,
+    after_json TEXT,
+    ts TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_ts
+    ON audit_log(ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_entity
+    ON audit_log(entity_type, entity_id);

--- a/handlers/admin_history.py
+++ b/handlers/admin_history.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from html import escape
+from typing import Any, Iterable
+
+from aiogram import Router, types
+from aiogram.filters import Command
+
+from keyboards import AuditUndoCB, build_audit_entry_keyboard
+from role_service import ROLE_ADMIN, ROLE_TRAINER
+from services.audit_service import AuditEntry, AuditService
+from utils.roles import require_roles
+
+router = Router()
+
+_ACTION_LABELS: dict[str, str] = {
+    "create": "створено",
+    "update": "оновлено",
+    "delete": "видалено",
+}
+
+_ENTITY_LABELS: dict[str, str] = {
+    "result": "Результат",
+    "template": "Шаблон",
+}
+
+_DEFAULT_LIMIT = 10
+
+
+@router.message(Command("history"), require_roles(ROLE_ADMIN, ROLE_TRAINER))
+async def cmd_history(
+    message: types.Message,
+    audit_service: AuditService,
+) -> None:
+    """Show recent audit entries for admins and coaches."""
+
+    limit, user_filter, error = _parse_arguments(message.text or "")
+    if error:
+        await message.answer(error)
+        return
+
+    entries = await audit_service.list_entries(limit=limit, user_id=user_filter)
+    if not entries:
+        await message.answer("Поки немає записів аудиту.")
+        return
+
+    for entry in entries:
+        text = _format_entry(entry)
+        await message.answer(
+            text,
+            reply_markup=build_audit_entry_keyboard(entry.id),
+            parse_mode="HTML",
+        )
+
+
+@router.callback_query(AuditUndoCB.filter(), require_roles(ROLE_ADMIN, ROLE_TRAINER))
+async def handle_undo(
+    callback: types.CallbackQuery,
+    callback_data: AuditUndoCB,
+    audit_service: AuditService,
+) -> None:
+    """Undo audit operation when requested from inline button."""
+
+    success = await audit_service.undo(callback_data.op_id)
+    if not success:
+        await callback.answer("Не вдалося виконати відкат.", show_alert=True)
+        return
+    await callback.answer("Відкат виконано.")
+    if callback.message:
+        await callback.message.answer(
+            f"✅ Операцію #{callback_data.op_id} відкотили."
+        )
+
+
+def _parse_arguments(text: str) -> tuple[int, int | None, str | None]:
+    parts = text.strip().split()
+    if len(parts) < 2:
+        return _DEFAULT_LIMIT, None, None
+    keyword = parts[1].lower()
+    if keyword == "last":
+        if len(parts) < 3:
+            return _DEFAULT_LIMIT, None, "Вкажіть кількість записів: /history last 5"
+        try:
+            limit = max(1, min(20, int(parts[2])))
+        except ValueError:
+            return _DEFAULT_LIMIT, None, "Кількість має бути числом."
+        return limit, None, None
+    if keyword == "user":
+        if len(parts) < 3:
+            return _DEFAULT_LIMIT, None, "Вкажіть ID користувача: /history user 123"
+        try:
+            user_id = int(parts[2])
+        except ValueError:
+            return _DEFAULT_LIMIT, None, "ID користувача має бути числом."
+        return _DEFAULT_LIMIT, user_id, None
+    return _DEFAULT_LIMIT, None, "Невідомий параметр. Використовуйте user або last."
+
+
+def _format_entry(entry: AuditEntry) -> str:
+    header = (
+        f"#{entry.id} • {entry.ts.strftime('%Y-%m-%d %H:%M:%S')} • "
+        f"👤 <code>{entry.user_id}</code>"
+    )
+    entity_label = _ENTITY_LABELS.get(entry.entity_type, entry.entity_type.title())
+    action_label = _ACTION_LABELS.get(entry.action, entry.action)
+    body = (
+        f"{entity_label} <code>{escape(entry.entity_id)}</code> — {action_label}"
+    )
+    sections: list[str] = [header, body]
+    if entry.action == "create":
+        sections.extend(_format_section("Стало", entry.after.items()))
+    elif entry.action == "delete":
+        sections.extend(_format_section("Було", entry.before.items()))
+    else:
+        sections.extend(_format_section("Було", entry.before.items()))
+        sections.extend(_format_section("Стало", entry.after.items()))
+    return "\n".join(sections)
+
+
+def _format_section(title: str, items: Iterable[tuple[str, Any]]) -> list[str]:
+    items = list(items)
+    if not items:
+        return []
+    lines = [f"<b>{title}:</b>"]
+    for key, value in sorted(items):
+        lines.append(
+            f"• <code>{escape(str(key))}</code>: {escape(_format_value(value))}"
+        )
+    return lines
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{value}"
+    if isinstance(value, bool):
+        return "так" if value else "ні"
+    if value is None:
+        return "—"
+    if isinstance(value, (list, dict)):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+__all__ = ["router"]

--- a/handlers/export_import.py
+++ b/handlers/export_import.py
@@ -143,7 +143,8 @@ async def confirm_import(
         await state.clear()
         return
 
-    result = await io_service.apply_import(preview)
+    actor_id = callback.from_user.id if callback.from_user else None
+    result = await io_service.apply_import(preview, user_id=actor_id)
     await state.clear()
     await callback.message.edit_text(
         _format_result(preview, result), reply_markup=None

--- a/keyboards.py
+++ b/keyboards.py
@@ -42,6 +42,12 @@ class RepeatCB(CallbackData, prefix="repeat"):
     athlete_id: int
 
 
+class AuditUndoCB(CallbackData, prefix="auditundo"):
+    """Callback factory for audit undo actions."""
+
+    op_id: int
+
+
 class CommentCB(CallbackData, prefix="comment"):
     """Callback factory for comment management."""
 
@@ -202,6 +208,21 @@ def get_repeat_keyboard(athlete_id: int) -> InlineKeyboardMarkup:
                 InlineKeyboardButton(
                     text="🔁 Повторити попередній результат",
                     callback_data=RepeatCB(athlete_id=athlete_id).pack(),
+                )
+            ]
+        ]
+    )
+
+
+def build_audit_entry_keyboard(op_id: int) -> InlineKeyboardMarkup:
+    """Build keyboard for undoing audit operation."""
+
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="↩️ Відкотити",
+                    callback_data=AuditUndoCB(op_id=op_id).pack(),
                 )
             ]
         ]

--- a/services/audit_service.py
+++ b/services/audit_service.py
@@ -1,0 +1,390 @@
+"""Audit log service with undo support for results and templates."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence, Literal
+
+ActionType = Literal["create", "update", "delete"]
+EntityType = Literal["result", "template"]
+
+
+@dataclass(slots=True, frozen=True)
+class AuditEntry:
+    """Single audit log record."""
+
+    id: int
+    user_id: int
+    action: str
+    entity_type: str
+    entity_id: str
+    before: dict[str, Any]
+    after: dict[str, Any]
+    ts: datetime
+
+
+class AuditService:
+    """Manage audit log entries and undo operations."""
+
+    _MIGRATION_PATH = Path("db/migrations/001_create_audit_log.sql")
+
+    def __init__(
+        self,
+        *,
+        results_db_path: Path | str = Path("data/results.db"),
+        template_path: Path | str = Path("data/sprint_templates.json"),
+    ) -> None:
+        self._db_path = Path(results_db_path)
+        self._template_path = Path(template_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._template_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    async def init(self) -> None:
+        """Ensure audit schema exists."""
+
+        async with self._lock:
+            await asyncio.to_thread(self._ensure_schema)
+
+    async def log_result_create(self, *, actor_id: int, result: Mapping[str, Any]) -> None:
+        await self._record(
+            actor_id=actor_id,
+            action="create",
+            entity_type="result",
+            entity_id=str(result.get("id")),
+            before=None,
+            after=result,
+        )
+
+    async def log_result_update(
+        self,
+        *,
+        actor_id: int,
+        entity_id: int,
+        before: Mapping[str, Any],
+        after: Mapping[str, Any],
+    ) -> None:
+        await self._record(
+            actor_id=actor_id,
+            action="update",
+            entity_type="result",
+            entity_id=str(entity_id),
+            before=before,
+            after=after,
+        )
+
+    async def log_result_delete(
+        self,
+        *,
+        actor_id: int,
+        result: Mapping[str, Any],
+    ) -> None:
+        await self._record(
+            actor_id=actor_id,
+            action="delete",
+            entity_type="result",
+            entity_id=str(result.get("id")),
+            before=result,
+            after=None,
+        )
+
+    async def log_template_create(
+        self,
+        *,
+        actor_id: int,
+        template_id: str,
+        after: Mapping[str, Any],
+    ) -> None:
+        await self._record(
+            actor_id=actor_id,
+            action="create",
+            entity_type="template",
+            entity_id=template_id,
+            before=None,
+            after=after,
+        )
+
+    async def log_template_update(
+        self,
+        *,
+        actor_id: int,
+        template_id: str,
+        before: Mapping[str, Any],
+        after: Mapping[str, Any],
+    ) -> None:
+        await self._record(
+            actor_id=actor_id,
+            action="update",
+            entity_type="template",
+            entity_id=template_id,
+            before=before,
+            after=after,
+        )
+
+    async def log_template_delete(
+        self,
+        *,
+        actor_id: int,
+        template_id: str,
+        before: Mapping[str, Any],
+    ) -> None:
+        await self._record(
+            actor_id=actor_id,
+            action="delete",
+            entity_type="template",
+            entity_id=template_id,
+            before=before,
+            after=None,
+        )
+
+    async def list_entries(
+        self,
+        *,
+        limit: int = 10,
+        user_id: int | None = None,
+    ) -> tuple[AuditEntry, ...]:
+        return await asyncio.to_thread(self._fetch_entries, limit, user_id)
+
+    async def undo(self, op_id: int) -> bool:
+        entry = await asyncio.to_thread(self._fetch_entry, op_id)
+        if entry is None:
+            return False
+        if entry.entity_type == "result":
+            return await asyncio.to_thread(self._undo_result, entry)
+        if entry.entity_type == "template":
+            return await asyncio.to_thread(self._undo_template, entry)
+        return False
+
+    # --- internal helpers -------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        script = self._MIGRATION_PATH.read_text(encoding="utf-8")
+        with self._connect() as conn:
+            conn.executescript(script)
+            conn.commit()
+
+    async def _record(
+        self,
+        *,
+        actor_id: int,
+        action: str,
+        entity_type: str,
+        entity_id: str,
+        before: Mapping[str, Any] | None,
+        after: Mapping[str, Any] | None,
+    ) -> None:
+        if actor_id <= 0:
+            raise ValueError("actor_id must be positive")
+        payload_before = json.dumps(before, ensure_ascii=False, sort_keys=True) if before else None
+        payload_after = json.dumps(after, ensure_ascii=False, sort_keys=True) if after else None
+        timestamp = datetime.now(UTC).isoformat(timespec="seconds")
+        await asyncio.to_thread(
+            self._insert_record,
+            actor_id,
+            action,
+            entity_type,
+            entity_id,
+            payload_before,
+            payload_after,
+            timestamp,
+        )
+
+    def _insert_record(
+        self,
+        actor_id: int,
+        action: str,
+        entity_type: str,
+        entity_id: str,
+        before_json: str | None,
+        after_json: str | None,
+        ts: str,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO audit_log (
+                    user_id,
+                    action,
+                    entity_type,
+                    entity_id,
+                    before_json,
+                    after_json,
+                    ts
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (actor_id, action, entity_type, entity_id, before_json, after_json, ts),
+            )
+            conn.commit()
+
+    def _fetch_entries(
+        self,
+        limit: int,
+        user_id: int | None,
+    ) -> tuple[AuditEntry, ...]:
+        limit = max(1, min(50, limit))
+        query = (
+            "SELECT id, user_id, action, entity_type, entity_id, before_json, after_json, ts "
+            "FROM audit_log"
+        )
+        args: list[object] = []
+        if user_id is not None:
+            query += " WHERE user_id = ?"
+            args.append(user_id)
+        query += " ORDER BY id DESC LIMIT ?"
+        args.append(limit)
+        with self._connect() as conn:
+            cur = conn.execute(query, tuple(args))
+            rows = cur.fetchall()
+        return tuple(self._row_to_entry(row) for row in rows)
+
+    def _fetch_entry(self, op_id: int) -> AuditEntry | None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT id, user_id, action, entity_type, entity_id, before_json, after_json, ts "
+                "FROM audit_log WHERE id = ?",
+                (op_id,),
+            )
+            row = cur.fetchone()
+        return self._row_to_entry(row) if row else None
+
+    def _row_to_entry(self, row: sqlite3.Row) -> AuditEntry:
+        before = json.loads(row["before_json"]) if row["before_json"] else {}
+        after = json.loads(row["after_json"]) if row["after_json"] else {}
+        return AuditEntry(
+            id=int(row["id"]),
+            user_id=int(row["user_id"]),
+            action=str(row["action"]),
+            entity_type=str(row["entity_type"]),
+            entity_id=str(row["entity_id"]),
+            before=before,
+            after=after,
+            ts=datetime.fromisoformat(str(row["ts"])),
+        )
+
+    def _undo_result(self, entry: AuditEntry) -> bool:
+        with self._connect() as conn:
+            if entry.action == "create":
+                cur = conn.execute(
+                    "DELETE FROM results WHERE id = ?",
+                    (int(entry.entity_id),),
+                )
+                conn.commit()
+                return cur.rowcount > 0
+            if entry.action == "update":
+                if not entry.before:
+                    return False
+                cur = conn.execute(
+                    """
+                    UPDATE results
+                    SET athlete_id = ?, athlete_name = ?, stroke = ?, distance = ?,
+                        total_seconds = ?, timestamp = ?, is_pr = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        entry.before["athlete_id"],
+                        entry.before.get("athlete_name", ""),
+                        entry.before["stroke"],
+                        entry.before["distance"],
+                        entry.before["total_seconds"],
+                        entry.before["timestamp"],
+                        int(bool(entry.before.get("is_pr", 0))),
+                        int(entry.entity_id),
+                    ),
+                )
+                conn.commit()
+                return cur.rowcount > 0
+            if entry.action == "delete":
+                if not entry.before:
+                    return False
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO results (
+                        id, athlete_id, athlete_name, stroke, distance,
+                        total_seconds, timestamp, is_pr
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        int(entry.entity_id),
+                        entry.before["athlete_id"],
+                        entry.before.get("athlete_name", ""),
+                        entry.before["stroke"],
+                        entry.before["distance"],
+                        entry.before["total_seconds"],
+                        entry.before["timestamp"],
+                        int(bool(entry.before.get("is_pr", 0))),
+                    ),
+                )
+                conn.commit()
+                return True
+        return False
+
+    def _undo_template(self, entry: AuditEntry) -> bool:
+        if entry.action == "create":
+            return self._remove_template(entry.entity_id)
+        if entry.action == "update":
+            if not entry.before:
+                return False
+            return self._upsert_template(entry.before)
+        if entry.action == "delete":
+            if not entry.before:
+                return False
+            return self._upsert_template(entry.before)
+        return False
+
+    def _load_templates(self) -> list[dict[str, Any]]:
+        if not self._template_path.exists():
+            return []
+        text = self._template_path.read_text(encoding="utf-8").strip()
+        if not text:
+            return []
+        data = json.loads(text)
+        if isinstance(data, list):
+            return [dict(item) for item in data]
+        return []
+
+    def _save_templates(self, items: Sequence[Mapping[str, Any]]) -> None:
+        payload = [dict(item) for item in items]
+        self._template_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def _remove_template(self, template_id: str) -> bool:
+        items = self._load_templates()
+        new_items = [item for item in items if str(item.get("template_id")) != template_id]
+        if len(new_items) == len(items):
+            return False
+        self._save_templates(new_items)
+        return True
+
+    def _upsert_template(self, payload: Mapping[str, Any]) -> bool:
+        template_id = str(payload.get("template_id"))
+        items = self._load_templates()
+        replaced = False
+        for index, item in enumerate(items):
+            if str(item.get("template_id")) == template_id:
+                items[index] = dict(payload)
+                replaced = True
+                break
+        if not replaced:
+            items.append(dict(payload))
+        self._save_templates(items)
+        return True
+
+
+__all__ = [
+    "ActionType",
+    "AuditEntry",
+    "AuditService",
+    "EntityType",
+]

--- a/tests/test_audit_undo.py
+++ b/tests/test_audit_undo.py
@@ -1,0 +1,91 @@
+import asyncio
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from services.audit_service import AuditService
+from services.io_service import ImportPreview, ImportRecord, IOService
+from template_service import TemplateService
+
+
+def test_undo_result_creation_restores_state(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        db_path = tmp_path / "results.db"
+        templates_path = tmp_path / "templates.json"
+        audit_service = AuditService(results_db_path=db_path, template_path=templates_path)
+        await audit_service.init()
+
+        io_service = IOService(db_path=db_path, audit_service=audit_service)
+        await io_service.init()
+
+        record = ImportRecord(
+            row_number=1,
+            athlete_id=101,
+            athlete_name="Tester",
+            stroke="freestyle",
+            distance=50,
+            total_seconds=25.5,
+            timestamp=datetime(2024, 5, 1, 8, 0),
+            is_pr=True,
+        )
+        preview = ImportPreview(rows=(record,), issues=(), total_rows=1)
+        await io_service.apply_import(preview, user_id=42)
+
+        entries = await audit_service.list_entries(limit=5)
+        assert entries, "Audit log must contain create entry"
+        entry = entries[0]
+        assert entry.action == "create"
+        assert entry.entity_type == "result"
+
+        with sqlite3.connect(db_path) as conn:
+            count_before = conn.execute("SELECT COUNT(*) FROM results").fetchone()[0]
+        assert count_before == 1
+
+        assert await audit_service.undo(entry.id)
+
+        with sqlite3.connect(db_path) as conn:
+            count_after = conn.execute("SELECT COUNT(*) FROM results").fetchone()[0]
+        assert count_after == 0
+
+    asyncio.run(scenario())
+
+
+def test_undo_template_update_and_delete(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        db_path = tmp_path / "results.db"
+        templates_path = tmp_path / "templates.json"
+        audit_service = AuditService(results_db_path=db_path, template_path=templates_path)
+        await audit_service.init()
+
+        template_service = TemplateService(storage_path=templates_path, audit_service=audit_service)
+        await template_service.init()
+
+        template = await template_service.create_template(
+            title="Test", dist=100, stroke="freestyle", segments=(25, 25, 25, 25), actor_id=7
+        )
+
+        updated = await template_service.update_template(
+            template.template_id,
+            hint="Новий опис",
+            actor_id=7,
+        )
+        assert updated.hint == "Новий опис"
+
+        entries = await audit_service.list_entries(limit=5)
+        update_entry = next(entry for entry in entries if entry.action == "update")
+        assert await audit_service.undo(update_entry.id)
+
+        restored = await template_service.get_template(template.template_id)
+        assert restored is not None
+        assert restored.hint == ""
+
+        assert await template_service.delete_template(template.template_id, actor_id=7)
+        entries = await audit_service.list_entries(limit=5)
+        delete_entry = next(entry for entry in entries if entry.action == "delete")
+        assert await audit_service.undo(delete_entry.id)
+
+        recovered = await template_service.get_template(template.template_id)
+        assert recovered is not None
+        assert recovered.title == template.title
+
+    asyncio.run(scenario())

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio
 from datetime import datetime
 from pathlib import Path
 
@@ -97,7 +98,7 @@ def test_apply_import_is_idempotent(tmp_path: Path) -> None:
         preview = await service.dry_run_import(csv_content.encode("utf-8"))
         assert len(preview.rows) == 2
 
-        result = await service.apply_import(preview)
+        result = await service.apply_import(preview, user_id=1)
         assert result.inserted == 2
         assert result.skipped == 0
 


### PR DESCRIPTION
## Summary
- add an audit_log table and asynchronous service capable of undoing result and template changes
- hook result import and template CRUD paths to the audit log and expose an /history admin command with inline undo actions
- provide undo keyboard helpers plus coverage for audit rollback scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddca1347d88325b192a5b478c60502