### PR TITLE
Add basic i18n translation utility

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -1,0 +1,92 @@
+"""Utilities for application internationalization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+_LOCALE_DATA: Dict[str, Dict[str, str]] = {}
+
+
+def _strip_quotes(value: str) -> str:
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def _parse_simple_yaml(content: str) -> Dict[str, Any]:
+    """Parse a limited subset of YAML used for locale files."""
+    root: Dict[str, Any] = {}
+    stack: list[Tuple[int, Dict[str, Any]]] = [(-1, root)]
+
+    for raw_line in content.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        line = raw_line.strip()
+        if ":" not in line:
+            raise ValueError(f"Invalid line in translation file: {raw_line!r}")
+
+        key_part, value_part = line.split(":", 1)
+        key = key_part.strip()
+        value = value_part.strip()
+
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+
+        if value == "":
+            nested: Dict[str, Any] = {}
+            parent[key] = nested
+            stack.append((indent, nested))
+            continue
+
+        parent[key] = _strip_quotes(value)
+
+    return root
+
+
+def _flatten_mapping(data: Dict[str, Any], prefix: str = "") -> Dict[str, str]:
+    """Flatten nested dictionaries into dot-separated keys."""
+    flattened: Dict[str, str] = {}
+    for key, value in data.items():
+        composite_key = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(value, dict):
+            flattened.update(_flatten_mapping(value, composite_key))
+        else:
+            flattened[composite_key] = str(value)
+    return flattened
+
+
+def _load_translations() -> Dict[str, Dict[str, str]]:
+    """Load translations from YAML files placed in the package directory."""
+    package_dir = Path(__file__).resolve().parent
+    translations: Dict[str, Dict[str, str]] = {}
+
+    for path in package_dir.glob("*.yaml"):
+        language_code = path.stem
+        content = path.read_text(encoding="utf-8")
+        parsed = _parse_simple_yaml(content)
+        translations[language_code] = _flatten_mapping(parsed)
+    return translations
+
+
+_LOCALE_DATA = _load_translations()
+
+
+def t(key: str, *, lang: str = "uk", **kwargs: Any) -> str:
+    """Return a translated string for the provided key and language code."""
+    try:
+        template = _LOCALE_DATA[lang][key]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise KeyError(f"Missing translation for '{key}' in '{lang}'") from exc
+
+    if kwargs:
+        return template.format(**kwargs)
+    return template
+
+
+__all__ = ["t"]

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -1,0 +1,5 @@
+menu:
+  start: "Привет, {name}!"
+  add_result: "Добавить результат"
+error:
+  invalid_time: "Неверный формат времени"

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -1,0 +1,5 @@
+menu:
+  start: "Привіт, {name}!"
+  add_result: "Додати результат"
+error:
+  invalid_time: "Невірний формат часу"

--- a/tests/test_i18n_basic.py
+++ b/tests/test_i18n_basic.py
@@ -1,0 +1,9 @@
+from i18n import t
+
+
+def test_returns_translation_for_ukrainian_locale() -> None:
+    assert t("menu.add_result", lang="uk") == "Додати результат"
+
+
+def test_placeholder_substitution() -> None:
+    assert t("menu.start", lang="ru", name="Никита") == "Привет, Никита!"


### PR DESCRIPTION
## Summary
- add a lightweight YAML loader and `t` helper for localized strings
- seed Ukrainian and Russian locale files with initial menu and error keys
- cover the translation helper with a basic pytest suite

## Testing
- pip install -r requirements.txt
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddcf4a95488325bca4632fe5a958d2