### PR TITLE
Add middleware for language selection

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
 _LOCALE_DATA: Dict[str, Dict[str, str]] = {}
+_LANGUAGE_CONTEXT: ContextVar[str] = ContextVar("language", default="uk")
 
 
 def _strip_quotes(value: str) -> str:
@@ -77,16 +79,36 @@ def _load_translations() -> Dict[str, Dict[str, str]]:
 _LOCALE_DATA = _load_translations()
 
 
-def t(key: str, *, lang: str = "uk", **kwargs: Any) -> str:
+def set_context_language(lang: str) -> Token[str]:
+    """Push language value to the context stack."""
+
+    return _LANGUAGE_CONTEXT.set(lang)
+
+
+def reset_context_language(token: Token[str]) -> None:
+    """Restore language context from token."""
+
+    _LANGUAGE_CONTEXT.reset(token)
+
+
+def get_current_language() -> str:
+    """Return language stored in the current execution context."""
+
+    return _LANGUAGE_CONTEXT.get()
+
+
+def t(key: str, *, lang: str | None = None, **kwargs: Any) -> str:
     """Return a translated string for the provided key and language code."""
+
+    language = lang or get_current_language()
     try:
-        template = _LOCALE_DATA[lang][key]
+        template = _LOCALE_DATA[language][key]
     except KeyError as exc:  # pragma: no cover - defensive branch
-        raise KeyError(f"Missing translation for '{key}' in '{lang}'") from exc
+        raise KeyError(f"Missing translation for '{key}' in '{language}'") from exc
 
     if kwargs:
         return template.format(**kwargs)
     return template
 
 
-__all__ = ["t"]
+__all__ = ["t", "get_current_language", "set_context_language", "reset_context_language"]

--- a/middlewares/i18n.py
+++ b/middlewares/i18n.py
@@ -1,0 +1,64 @@
+"""Middleware for selecting user language and populating context."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict
+
+from aiogram import BaseMiddleware
+from aiogram.types import TelegramObject
+
+from i18n import reset_context_language, set_context_language
+from services.user_service import UserService
+
+Handler = Callable[[TelegramObject, Dict[str, Any]], Awaitable[Any]]
+
+
+class I18nMiddleware(BaseMiddleware):
+    """Ensure handlers operate with the language stored in user profile."""
+
+    def __init__(
+        self,
+        user_service: UserService,
+        *,
+        default_language: str = "uk",
+        context_key: str = "lang",
+    ) -> None:
+        self._user_service = user_service
+        self._default_language = default_language
+        self._context_key = context_key
+
+    async def __call__(
+        self, handler: Handler, event: TelegramObject, data: Dict[str, Any]
+    ) -> Any:
+        lang = await self._resolve_language(event, data)
+        data[self._context_key] = lang
+
+        event_ctx = getattr(event, "ctx", None)
+        if event_ctx is not None:
+            try:
+                event_ctx[self._context_key] = lang
+            except (TypeError, AttributeError):  # pragma: no cover - defensive
+                pass
+
+        token = set_context_language(lang)
+        try:
+            return await handler(event, data)
+        finally:
+            reset_context_language(token)
+
+    async def _resolve_language(
+        self, event: TelegramObject, data: Dict[str, Any]
+    ) -> str:
+        lang = data.get(self._context_key)
+        if isinstance(lang, str) and lang:
+            return lang
+
+        user = getattr(event, "from_user", None)
+        if user is None:
+            return self._default_language
+
+        profile = await self._user_service.get_profile(user.id)
+        if profile and getattr(profile, "language", None):
+            return profile.language
+
+        return self._default_language

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS user_profiles (
     role TEXT NOT NULL,
     full_name TEXT NOT NULL,
     group_name TEXT DEFAULT NULL,
-    language TEXT NOT NULL DEFAULT 'ru',
+    language TEXT NOT NULL DEFAULT 'uk',
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/tests/test_i18n_middleware.py
+++ b/tests/test_i18n_middleware.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+from i18n import get_current_language, t
+from middlewares.i18n import I18nMiddleware
+
+
+class StubUserService:
+    def __init__(self, languages: dict[int, str]) -> None:
+        self._languages = languages
+
+    async def get_profile(self, telegram_id: int) -> Any | None:
+        language = self._languages.get(telegram_id)
+        if language is None:
+            return None
+        return SimpleNamespace(language=language)
+
+
+def test_user_language_is_used_from_profile() -> None:
+    service = StubUserService({1: "ru"})
+    middleware = I18nMiddleware(service)
+    event = SimpleNamespace(from_user=SimpleNamespace(id=1), ctx={})
+    data: dict[str, Any] = {}
+
+    async def scenario() -> tuple[str, str, str]:
+        async def handler(evt, ctx):
+            return t("menu.add_result"), ctx["lang"], evt.ctx["lang"]
+
+        return await middleware(handler, event, data)
+
+    text, data_lang, ctx_lang = asyncio.run(scenario())
+    assert text == "Добавить результат"
+    assert data_lang == "ru"
+    assert ctx_lang == "ru"
+    assert get_current_language() == "uk"
+
+
+def test_default_language_is_used_when_profile_missing() -> None:
+    service = StubUserService({})
+    middleware = I18nMiddleware(service)
+    event = SimpleNamespace(from_user=SimpleNamespace(id=2), ctx={})
+    data: dict[str, Any] = {}
+
+    async def scenario() -> tuple[str, str, str]:
+        async def handler(evt, ctx):
+            return t("menu.start", name="Анна"), ctx["lang"], evt.ctx["lang"]
+
+        return await middleware(handler, event, data)
+
+    text, data_lang, ctx_lang = asyncio.run(scenario())
+    assert text == "Привіт, Анна!"
+    assert data_lang == "uk"
+    assert ctx_lang == "uk"
+    assert get_current_language() == "uk"


### PR DESCRIPTION
## Summary
- add middleware that loads user language from profiles and places it into handler context
- expose context-aware helpers so `t()` can default to the active language and default new profiles to Ukrainian
- cover middleware behaviour with tests verifying Russian and default Ukrainian strings

## Testing
- pip install -r requirements.txt
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de5262024483259125bb6e8c45e514