### PR TITLE
Add i18n support for sprint reports

### DIFF
--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -72,3 +72,27 @@ res:
     total: "• Общее время: {total}"
     sob: "• Sum of Best: {sob}"
     splits: "• Отрезки: {splits}"
+report:
+  title: "Спринт: {stroke} • {distance} м"
+  col:
+    segment: "Сегмент"
+    time: "Время"
+    ms: "м/с"
+    percent_best: "% к лучшему"
+  chart:
+    pace: "Темп (сек/100м)"
+  footer:
+    total: "Общее время"
+    pr: "PR"
+    sob: "SoB"
+  status:
+    yes: "да"
+    no: "—"
+  caption:
+    last: "Последняя попытка: {distance} м, {stroke}."
+  errors:
+    mention: "Не удалось определить пользователя по нику."
+    invalid_id: "Идентификатор спортсмена должен быть числом."
+    forbidden: "У вас нет доступа к этому спортсмену."
+    no_results: "Для спортсмена ещё нет зафиксированных результатов."
+    empty_report: "Не удалось сгенерировать отчёт для пустого результата."

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -71,3 +71,27 @@ res:
     total: "• Загальний час: {total}"
     sob: "• Sum of Best: {sob}"
     splits: "• Сегменти: {splits}"
+report:
+  title: "Спринт: {stroke} • {distance} м"
+  col:
+    segment: "Сегмент"
+    time: "Час"
+    ms: "м/с"
+    percent_best: "% до найкращого"
+  chart:
+    pace: "Темп (с/100м)"
+  footer:
+    total: "Загальний час"
+    pr: "PR"
+    sob: "SoB"
+  status:
+    yes: "так"
+    no: "—"
+  caption:
+    last: "Остання спроба: {distance} м, {stroke}."
+  errors:
+    mention: "Не вдалося визначити користувача за нікнеймом."
+    invalid_id: "Ідентифікатор спортсмена має бути числом."
+    forbidden: "У вас немає доступу до цього спортсмена."
+    no_results: "Для спортсмена ще немає зафіксованих результатів."
+    empty_report: "Не вдалося згенерувати звіт для порожнього результату."

--- a/tests/test_image_report.py
+++ b/tests/test_image_report.py
@@ -32,4 +32,4 @@ def test_generate_image_report_snapshot() -> None:
     assert len(image_bytes) < 150_000
 
     digest = hashlib.sha256(image_bytes).hexdigest()
-    assert digest == "3924eb08b4a343051deba5e18c842ca9984ffbbdf6fcd78443db93505ca5d677"
+    assert digest == "2ef5a197cbc0f29bc4a68f0291ac067b985385b7de1d2811d101fb27c8c30705"

--- a/tests/test_reports_i18n.py
+++ b/tests/test_reports_i18n.py
@@ -1,0 +1,85 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+from i18n import reset_context_language, set_context_language, t
+
+
+def _load_reports_module(monkeypatch: pytest.MonkeyPatch):
+    fake_services = types.ModuleType("services")
+    fake_services.ws_pr = types.SimpleNamespace(get_all_values=lambda: [])
+    fake_services.ws_results = types.SimpleNamespace(get_all_values=lambda: [])
+    monkeypatch.setitem(sys.modules, "services", fake_services)
+    module_name = "handlers.reports"
+    if module_name in sys.modules:
+        return importlib.reload(sys.modules[module_name])
+    return importlib.import_module(module_name)
+
+
+@pytest.mark.parametrize("lang", ["uk", "ru"])
+def test_report_messages_use_translations(
+    monkeypatch: pytest.MonkeyPatch, lang: str
+) -> None:
+    module = _load_reports_module(monkeypatch)
+    token = set_context_language(lang)
+    try:
+        assert module.build_report_error("mention") == t("report.errors.mention")
+        assert module.build_report_error("invalid_id") == t("report.errors.invalid_id")
+        assert module.build_report_error("forbidden") == t("report.errors.forbidden")
+        assert module.build_report_error("no_results") == t("report.errors.no_results")
+        assert module.build_report_error("empty_report") == t(
+            "report.errors.empty_report"
+        )
+        caption = module.build_report_caption(200, "freestyle")
+        assert caption == t("report.caption.last", distance=200, stroke="freestyle")
+    finally:
+        reset_context_language(token)
+
+
+def test_generate_image_report_uses_translations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("reports.image_report")
+
+    mapping = {
+        "report.title": "Title {stroke} {distance}",
+        "report.col.segment": "Segment",
+        "report.col.time": "Time",
+        "report.col.ms": "Speed",
+        "report.col.percent_best": "%",
+        "report.chart.pace": "Pace",
+        "report.footer.total": "Total",
+        "report.footer.pr": "PR",
+        "report.footer.sob": "SoB",
+        "report.status.yes": "Yes",
+        "report.status.no": "No",
+    }
+    used_keys: list[str] = []
+
+    def fake_t(key: str, **kwargs) -> str:
+        used_keys.append(key)
+        template = mapping[key]
+        if kwargs:
+            return template.format(**kwargs)
+        return template
+
+    monkeypatch.setattr(module, "t", fake_t)
+
+    payload = module.AttemptReport(
+        athlete_name="Test",
+        stroke="freestyle",
+        distance=100,
+        timestamp="2024-01-01T00:00:00",
+        total_time=60.0,
+        segments=[module.SegmentReportRow(time=30.0, distance=50.0, best=29.5)],
+        total_is_pr=True,
+        sob_improved=False,
+    )
+
+    result = module.generate_image_report(payload)
+
+    assert isinstance(result, bytes)
+    for key in mapping:
+        assert key in used_keys


### PR DESCRIPTION
## Summary
- localize report command responses through translation helpers
- translate sprint report image labels with new i18n keys
- cover report localization with tests and refresh the image snapshot

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de63da60908325bfb950d7d35a76ec