### PR TITLE
Localize search empty state messages

### DIFF
--- a/handlers/search.py
+++ b/handlers/search.py
@@ -398,14 +398,19 @@ def _format_results(page: SearchPage, data: Mapping[str, Any]) -> str:
         athlete_name = item.athlete_name or f"ID {item.athlete_id}"
         timestamp = item.timestamp.strftime("%d.%m.%Y %H:%M")
         pr_flag = t("search.card.pr_flag") if item.is_pr else ""
-        card = "\n".join(
-            [
-                f"{idx}. {timestamp} • {distance_label} • {style_label}",
-                f"   👤 {athlete_name} ({item.athlete_id})",
-                f"   ⏱ {fmt_time(item.total_seconds)}{pr_flag}",
-            ]
+        parts.append(
+            t(
+                "search.item_fmt",
+                idx=idx,
+                timestamp=timestamp,
+                distance=distance_label,
+                stroke=style_label,
+                athlete=athlete_name,
+                athlete_id=item.athlete_id,
+                total=fmt_time(item.total_seconds),
+                pr_flag=pr_flag,
+            )
         )
-        parts.append(card)
     return "\n\n".join(parts)
 
 

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -197,6 +197,7 @@ search:
   title: "🔎 Результаты поиска"
   empty: "По заданным фильтрам ничего не найдено."
   page: "Страница {cur} из {total}"
+  item_fmt: "{idx}. {timestamp} • {distance} • {stroke}\n   👤 {athlete} ({athlete_id})\n   ⏱ {total}{pr_flag}"
   report_btn: "Отчёт #{idx}"
   prev: "◀️ Назад"
   next: "Вперёд ▶️"

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -196,6 +196,7 @@ search:
   title: "🔎 Результати пошуку"
   empty: "За заданими фільтрами нічого не знайдено."
   page: "Сторінка {cur} з {total}"
+  item_fmt: "{idx}. {timestamp} • {distance} • {stroke}\n   👤 {athlete} ({athlete_id})\n   ⏱ {total}{pr_flag}"
   report_btn: "Звіт #{idx}"
   prev: "◀️ Назад"
   next: "Вперед ▶️"

--- a/tests/test_query_service_i18n.py
+++ b/tests/test_query_service_i18n.py
@@ -1,0 +1,71 @@
+"""Tests for localized responses from query service consumers."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.base import StorageKey
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from handlers.search import SearchStates, select_pr
+from i18n import reset_context_language, set_context_language, t
+from keyboards import SearchFilterCB
+from services.query_service import SearchPage
+
+
+class DummyMessage:
+    """Simplified message stub capturing bot replies."""
+
+    def __init__(self) -> None:
+        self.text = ""
+        self.from_user = SimpleNamespace(id=1)
+        self.chat = SimpleNamespace(id=1)
+        self.answer = AsyncMock()
+
+
+class DummyCallback:
+    """Minimal callback stub for invoking handlers."""
+
+    def __init__(self, message: DummyMessage) -> None:
+        self.message = message
+        self.from_user = message.from_user
+        self.answer = AsyncMock()
+
+
+def _make_state() -> FSMContext:
+    storage = MemoryStorage()
+    key = StorageKey(bot_id=1, chat_id=1, user_id=1)
+    return FSMContext(storage=storage, key=key)
+
+
+class EmptyQueryService:
+    """Query service stub returning no results."""
+
+    async def search_results(self, filters, *, page: int, page_size: int) -> SearchPage:  # type: ignore[override]
+        return SearchPage(items=(), total=0, page=1, pages=0)
+
+
+@pytest.mark.parametrize("lang", ["uk", "ru"])
+def test_empty_results_message_localized(lang: str) -> None:
+    async def scenario() -> None:
+        state = _make_state()
+        await state.set_state(SearchStates.choose_pr)
+        callback = DummyCallback(DummyMessage())
+        service = EmptyQueryService()
+
+        await select_pr(
+            callback, state, SearchFilterCB(field="pr", value="all"), service
+        )
+
+        args, _ = callback.message.answer.await_args
+        assert args[0] == t("search.empty")
+
+    token = set_context_language(lang)
+    try:
+        asyncio.run(scenario())
+    finally:
+        reset_context_language(token)


### PR DESCRIPTION
## Summary
- replace hardcoded search result formatting with localized template strings
- add Russian and Ukrainian translations for the formatted search items
- cover empty search responses with a dedicated test to ensure localized messaging

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df0ce95f9c832598ec7a8cc25e46db