### PR TITLE
Add structured error codes for parse time utilities

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 from aiogram.fsm.state import State, StatesGroup
 
-from .parse_time import parse_splits, parse_total, validate_splits
+from .parse_time import (
+    ParseTimeError,
+    ParseTimeErrorCode,
+    parse_splits,
+    parse_total,
+    validate_splits,
+)
 
 __all__ = [
     "AddResult",
     "TemplateStates",
     "fmt_time",
     "get_segments",
+    "ParseTimeError",
+    "ParseTimeErrorCode",
     "parse_splits",
     "parse_total",
     "pr_key",

--- a/utils/parse_time.py
+++ b/utils/parse_time.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Iterable, Sequence
+from enum import Enum
+from typing import Iterable, Mapping, Sequence
 
 _TIME_RE = re.compile(
     r"""
@@ -17,16 +18,38 @@ _TIME_RE = re.compile(
 )
 
 
+class ParseTimeErrorCode(str, Enum):
+    """Translation keys for time parsing errors."""
+
+    INVALID_TIME = "error.invalid_time"
+    INVALID_INPUT = "error.invalid_input"
+    SPLITS_MISMATCH = "error.splits_mismatch"
+
+
+class ParseTimeError(ValueError):
+    """Exception that carries a translation key for parse-time failures."""
+
+    def __init__(
+        self,
+        code: ParseTimeErrorCode,
+        *,
+        context: Mapping[str, object] | None = None,
+    ) -> None:
+        self.code = code
+        self.context: Mapping[str, object] = dict(context or {})
+        super().__init__(code.value)
+
+
 def parse_total(raw: str) -> float:
     """Parse total swim time from a string into seconds."""
 
     text = raw.strip()
     if not text:
-        raise ValueError("time value is empty")
+        raise ParseTimeError(ParseTimeErrorCode.INVALID_TIME)
 
     match = _TIME_RE.match(text)
     if not match:
-        raise ValueError(f"invalid time format: {raw!r}")
+        raise ParseTimeError(ParseTimeErrorCode.INVALID_TIME)
 
     plain = match.group("plain")
     if plain is not None:
@@ -35,13 +58,13 @@ def parse_total(raw: str) -> float:
         minutes = int(match.group("minutes"))
         seconds = int(match.group("seconds"))
         if seconds >= 60:
-            raise ValueError("seconds part must be less than 60")
+            raise ParseTimeError(ParseTimeErrorCode.INVALID_TIME)
         fraction = match.group("fraction") or ""
         frac_value = int(fraction) / (10 ** len(fraction)) if fraction else 0.0
         value = minutes * 60 + seconds + frac_value
 
     if value < 0:
-        raise ValueError("time value must be non-negative")
+        raise ParseTimeError(ParseTimeErrorCode.INVALID_TIME)
 
     return value
 
@@ -56,10 +79,10 @@ def parse_splits(items: Sequence[str | float | int]) -> list[float]:
         elif isinstance(item, (int, float)):
             value = float(item)
         else:
-            raise ValueError(f"unsupported split value: {item!r}")
+            raise ParseTimeError(ParseTimeErrorCode.INVALID_INPUT)
 
         if value < 0:
-            raise ValueError("split value must be non-negative")
+            raise ParseTimeError(ParseTimeErrorCode.INVALID_TIME)
         parsed.append(value)
 
     return parsed
@@ -69,14 +92,17 @@ def validate_splits(total: float, splits: Iterable[float], tol: float = 0.20) ->
     """Validate that the sum of splits matches the total within tolerance."""
 
     if tol < 0:
-        raise ValueError("tolerance must be non-negative")
+        raise ParseTimeError(ParseTimeErrorCode.INVALID_INPUT)
     if total < 0:
-        raise ValueError("total time must be non-negative")
+        raise ParseTimeError(ParseTimeErrorCode.INVALID_TIME)
 
     splits_list = list(splits)
     if any(value < 0 for value in splits_list):
-        raise ValueError("split values must be non-negative")
+        raise ParseTimeError(ParseTimeErrorCode.INVALID_TIME)
 
     diff = abs(sum(splits_list) - total)
     if diff > tol:
-        raise ValueError("sum of splits does not match total within tolerance")
+        raise ParseTimeError(
+            ParseTimeErrorCode.SPLITS_MISMATCH,
+            context={"diff": diff},
+        )


### PR DESCRIPTION
## Summary
- replace human readable parse_time ValueErrors with ParseTimeError carrying translation codes
- expose the new error types through utils and attach mismatch context for split validation
- update parse_time tests to assert on error codes and cover invalid input scenarios

## Testing
- pip install -r requirements.txt
- isort utils/parse_time.py utils/__init__.py tests/test_parse_time.py
- black utils/parse_time.py utils/__init__.py tests/test_parse_time.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df11cd7da8832584e3013a6e11e0de