### PR TITLE
Add quiet hours notification queue

### DIFF
--- a/backup_service.py
+++ b/backup_service.py
@@ -13,6 +13,8 @@ from typing import Any, Sequence
 
 from aiogram import Bot
 
+from notifications import send_notification
+
 try:  # pragma: no cover - optional dependency
     import boto3
     from botocore.client import BaseClient
@@ -263,15 +265,7 @@ class BackupService:
         if not self.admin_chat_ids:
             return
         for chat_id in self.admin_chat_ids:
-            try:
-                await self.bot.send_message(chat_id, text)
-            except Exception as exc:  # pragma: no cover - network dependent
-                logger.warning(
-                    "Failed to send backup notification to %s: %s",
-                    chat_id,
-                    exc,
-                    exc_info=True,
-                )
+            await send_notification(self.bot, chat_id, text)
 
     def _get_client(self) -> BaseClient:
         self._ensure_available()

--- a/handlers/messages.py
+++ b/handlers/messages.py
@@ -13,6 +13,7 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from chat_service import ChatService
+from notifications import send_notification
 from role_service import ROLE_ADMIN, ROLE_ATHLETE, ROLE_TRAINER, RoleService
 from services import get_athlete_name, get_registered_athletes
 
@@ -459,10 +460,7 @@ async def process_text(
         )
         target_id = trainer_id
 
-    try:
-        await bot.send_message(chat_id=target_id, text=body)
-    except Exception as exc:  # pragma: no cover - network interaction
-        logger.warning("Failed to deliver chat notification to %s: %s", target_id, exc)
+    await send_notification(bot, target_id, body)
 
     await _show_dialog(
         event=message,

--- a/tests/test_quiet_notifications.py
+++ b/tests/test_quiet_notifications.py
@@ -1,0 +1,93 @@
+import asyncio
+from asyncio import QueueEmpty
+
+import pytest
+
+import notifications
+
+
+class DummyBot:
+    def __init__(self) -> None:
+        self.sent: list[tuple[int, str, dict[str, object]]] = []
+
+    async def send_message(self, chat_id: int, text: str, **kwargs: object) -> None:
+        self.sent.append((chat_id, text, dict(kwargs)))
+
+
+@pytest.fixture(autouse=True)
+def clear_notification_queue() -> None:
+    queue = notifications.NOTIFICATION_QUEUE
+    while True:
+        try:
+            queue.get_nowait()
+        except QueueEmpty:
+            break
+        else:
+            queue.task_done()
+    yield
+    while True:
+        try:
+            queue.get_nowait()
+        except QueueEmpty:
+            break
+        else:
+            queue.task_done()
+
+
+def test_send_notification_queues_during_quiet_hours(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def scenario() -> None:
+        async def always_quiet(*_: object, **__: object) -> bool:
+            return True
+
+        monkeypatch.setattr(notifications, "is_quiet_now", always_quiet)
+
+        bot = DummyBot()
+        await notifications.send_notification(bot, 123, "hello")
+
+        assert bot.sent == []
+        assert notifications.NOTIFICATION_QUEUE.qsize() == 1
+
+    asyncio.run(scenario())
+
+
+def test_send_notification_sends_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def scenario() -> None:
+        async def never_quiet(*_: object, **__: object) -> bool:
+            return False
+
+        monkeypatch.setattr(notifications, "is_quiet_now", never_quiet)
+
+        bot = DummyBot()
+        await notifications.send_notification(bot, 321, "hi")
+
+        assert notifications.NOTIFICATION_QUEUE.empty()
+        assert bot.sent == [(321, "hi", {})]
+
+    asyncio.run(scenario())
+
+
+def test_drain_queue_flushes_notifications(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def scenario() -> None:
+        async def always_quiet(*_: object, **__: object) -> bool:
+            return True
+
+        bot = DummyBot()
+        monkeypatch.setattr(notifications, "is_quiet_now", always_quiet)
+        await notifications.send_notification(bot, 11, "queued")
+
+        async def never_quiet(*_: object, **__: object) -> bool:
+            return False
+
+        monkeypatch.setattr(notifications, "is_quiet_now", never_quiet)
+        task = asyncio.create_task(notifications.drain_queue(interval=0.01))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert notifications.NOTIFICATION_QUEUE.empty()
+        assert bot.sent == [(11, "queued", {})]
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- parse quiet hours configuration and add helper APIs to queue or send notifications immediately
- route notification entry points through the quiet-hours aware sender and drain the queue in a background task
- cover notification queue behaviour with new pytest tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df15a49acc83258f84e3c0d27b4846