### PR TITLE
Add JSON logging test coverage

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,16 +3,33 @@ import json
 from utils.logger import get_logger
 
 
-def test_logger_emits_json(capfd) -> None:
+def test_logger_emits_valid_json_lines(capfd) -> None:
     logger = get_logger("tests.logger.json")
+
     logger.info("hello %s", "world")
+    logger.error(
+        "boom",
+        extra={"user_id": 42, "cmd": "/start", "latency_ms": 123},
+    )
 
     captured = capfd.readouterr()
-    line = captured.err.strip() or captured.out.strip()
-    assert line, "logger should emit a line"
+    output = "".join(part for part in (captured.err, captured.out) if part)
+    lines = [line for line in output.splitlines() if line.strip()]
 
-    payload = json.loads(line)
-    assert payload["msg"] == "hello world"
-    assert payload["level"] == "INFO"
-    for key in ("ts", "level", "msg"):
-        assert key in payload
+    assert len(lines) == 2, f"expected two log lines, got {lines!r}"
+
+    first_payload = json.loads(lines[0])
+    second_payload = json.loads(lines[1])
+
+    for payload in (first_payload, second_payload):
+        for key in ("ts", "level", "msg"):
+            assert key in payload
+
+    assert first_payload["msg"] == "hello world"
+    assert first_payload["level"] == "INFO"
+
+    assert second_payload["msg"] == "boom"
+    assert second_payload["level"] == "ERROR"
+    assert second_payload["user_id"] == 42
+    assert second_payload["cmd"] == "/start"
+    assert second_payload["latency_ms"] == 123


### PR DESCRIPTION
## Summary
- extend logger test to assert multiple JSON log lines and optional fields

## Testing
- pytest tests/test_logger.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e198b1ea108325b8f3c49f24d48906