### PR TITLE
Add turn analytics command and progress summaries

### DIFF
--- a/handlers/progress.py
+++ b/handlers/progress.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from datetime import datetime
-from typing import Iterable
+from typing import Iterable, Sequence
 
 import matplotlib
 from aiogram import F, Router, types
@@ -13,10 +14,33 @@ from aiogram.types import BufferedInputFile, InlineKeyboardButton, InlineKeyboar
 
 from role_service import ROLE_ATHLETE, RoleService
 from services import ws_athletes, ws_results
+from services.stats_service import StatsPeriod, StatsService, TurnProgressResult
 from utils import fmt_time
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402  # isort:skip
+
+
+_SUPPORTED_TURN_STROKES = ("breaststroke", "butterfly")
+_STROKE_ALIASES = {
+    "breast": "breaststroke",
+    "breaststroke": "breaststroke",
+    "breastroke": "breaststroke",
+    "breast-stroke": "breaststroke",
+    "br": "breaststroke",
+    "брас": "breaststroke",
+    "брасс": "breaststroke",
+    "butterfly": "butterfly",
+    "fly": "butterfly",
+    "баттерфляй": "butterfly",
+    "дельфин": "butterfly",
+    "батерфляй": "butterfly",
+    "bf": "butterfly",
+}
+_STROKE_TITLES = {
+    "breaststroke": "Брасс",
+    "butterfly": "Баттерфляй",
+}
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -151,8 +175,194 @@ def _build_progress_plot(
     return buf.getvalue()
 
 
+def _figure_to_png(fig: plt.Figure) -> bytes:
+    """Serialize matplotlib figure into PNG bytes."""
+
+    buf = io.BytesIO()
+    fig.tight_layout()
+    fig.savefig(buf, format="png", dpi=150)
+    plt.close(fig)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def _normalize_stroke(value: str | None) -> str | None:
+    """Return canonical stroke identifier or ``None`` if unsupported."""
+
+    if not value:
+        return None
+    lookup = value.strip().lower()
+    return _STROKE_ALIASES.get(lookup)
+
+
+def _stroke_title(value: str) -> str:
+    """Return human-readable stroke label for progress messages."""
+
+    return _STROKE_TITLES.get(value, value.title())
+
+
+def _group_turn_sessions(rows: Sequence[dict]) -> list[dict]:
+    """Group raw turn rows by training session preserving order."""
+
+    sessions: OrderedDict[int, dict] = OrderedDict()
+    for row in rows:
+        session = sessions.setdefault(
+            row["result_id"],
+            {
+                "timestamp": row["timestamp"],
+                "distance": row["distance"],
+                "turns": [],
+            },
+        )
+        session["turns"].append(row)
+    ordered: list[dict] = []
+    for session in sessions.values():
+        session["turns"].sort(key=lambda item: item["turn_number"])
+        ordered.append(session)
+    return ordered
+
+
+def _build_turn_efficiency_plot(
+    sessions: Sequence[dict], athlete_name: str, stroke: str
+) -> bytes | None:
+    """Plot average turn efficiency per session."""
+
+    points = []
+    for entry in sessions:
+        turns = [
+            row for row in entry["turns"] if row.get("total_turn_time") is not None
+        ]
+        if not turns:
+            continue
+        average = sum(row["total_turn_time"] for row in turns) / len(turns)
+        points.append((entry["timestamp"], average))
+    if not points:
+        return None
+    dates, values = zip(*sorted(points, key=lambda item: item[0]))
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(dates, values, marker="o", linewidth=2)
+    ax.set_title(
+        f"Ефективність поворотів ({_stroke_title(stroke)}) – {athlete_name or 'спортсмен'}"
+    )
+    ax.set_xlabel("Дата тренування")
+    ax.set_ylabel("Середній час повороту, с")
+    ax.grid(True, linestyle="--", alpha=0.4)
+    fig.autofmt_xdate()
+    return _figure_to_png(fig)
+
+
+def _build_turn_comparison_plot(
+    sessions: Sequence[dict], athlete_name: str, stroke: str
+) -> bytes | None:
+    """Plot comparison of turn times for the most recent session."""
+
+    if not sessions:
+        return None
+    latest = max(sessions, key=lambda item: item["timestamp"])
+    turns = [row for row in latest["turns"] if row.get("total_turn_time") is not None]
+    if not turns:
+        return None
+    turns.sort(key=lambda row: row["turn_number"])
+    labels = [f"#{row['turn_number']}" for row in turns]
+    values = [row["total_turn_time"] for row in turns]
+    fig, ax = plt.subplots(figsize=(10, 6))
+    bars = ax.bar(labels, values, color="#1f77b4")
+    ax.set_title(
+        f"Порівняння поворотів (останній заплив) – {athlete_name or 'спортсмен'}"
+    )
+    ax.set_xlabel("Номер повороту")
+    ax.set_ylabel("Час, с")
+    ax.bar_label(bars, fmt="{:.2f}")
+    return _figure_to_png(fig)
+
+
+def _build_turn_heatmap(
+    sessions: Sequence[dict], athlete_name: str, stroke: str
+) -> bytes | None:
+    """Return heatmap visualising turn efficiency per session."""
+
+    if not sessions:
+        return None
+    turn_numbers = sorted(
+        {row["turn_number"] for item in sessions for row in item["turns"]}
+    )
+    if not turn_numbers:
+        return None
+    session_keys = sorted(sessions, key=lambda item: item["timestamp"])
+    matrix: list[list[float | None]] = []
+    for turn_number in turn_numbers:
+        row_values: list[float | None] = []
+        for session in session_keys:
+            value = None
+            for item in session["turns"]:
+                if item["turn_number"] == turn_number:
+                    value = item.get("total_turn_time")
+                    break
+            row_values.append(value)
+        matrix.append(row_values)
+    if not any(any(value is not None for value in row) for row in matrix):
+        return None
+    fig, ax = plt.subplots(figsize=(10, 6))
+    clean_matrix = [
+        [value if value is not None else 0.0 for value in row] for row in matrix
+    ]
+    im = ax.imshow(clean_matrix, aspect="auto", cmap="viridis")
+    ax.set_title(
+        f"Теплова карта поворотів ({_stroke_title(stroke)}) – {athlete_name or 'спортсмен'}"
+    )
+    ax.set_xlabel("Тренування")
+    ax.set_ylabel("Номер повороту")
+    ax.set_xticks(range(len(session_keys)))
+    ax.set_xticklabels(
+        [session["timestamp"].strftime("%d.%m") for session in session_keys],
+        rotation=45,
+    )
+    ax.set_yticks(range(len(turn_numbers)))
+    ax.set_yticklabels([str(num) for num in turn_numbers])
+    cbar = fig.colorbar(im, ax=ax)
+    cbar.set_label("Час, с")
+    return _figure_to_png(fig)
+
+
+def _format_turn_summary(stroke: str, progress: Sequence[TurnProgressResult]) -> str:
+    """Return formatted summary highlighting best and worst turns."""
+
+    if not progress:
+        return (
+            f"<b>Аналіз поворотів ({_stroke_title(stroke)})</b>\n"
+            "Недостатньо даних для оцінки."
+        )
+    sorted_progress = sorted(
+        progress, key=lambda item: item.improvement_rate, reverse=True
+    )
+    top = sorted_progress[:3]
+    worst = sorted(progress, key=lambda item: item.improvement_rate)[:3]
+    lines = [f"<b>Аналіз поворотів ({_stroke_title(stroke)})</b>"]
+    lines.append("🔝 Топ-3 ефективних поворотів:")
+    for item in top:
+        lines.append(
+            "• #{num}: {rate:+.1f}% (тренд {trend:+.3f} c)".format(
+                num=item.turn_number,
+                rate=item.improvement_rate,
+                trend=item.efficiency_trend,
+            )
+        )
+    lines.append("⚠️ Потребують уваги:")
+    for item in worst:
+        lines.append(
+            "• #{num}: {rate:+.1f}% (тренд {trend:+.3f} c)".format(
+                num=item.turn_number,
+                rate=item.improvement_rate,
+                trend=item.efficiency_trend,
+            )
+        )
+    return "\n".join(lines)
+
+
 async def _send_progress_report(
-    event: types.Message | types.CallbackQuery, athlete_id: int
+    event: types.Message | types.CallbackQuery,
+    athlete_id: int,
+    stats_service: StatsService,
 ) -> None:
     """Render progress for athlete and send to requester."""
 
@@ -199,18 +409,40 @@ async def _send_progress_report(
         "<b>Динаміка за дистанціями</b>\n" + table_text,
         parse_mode="HTML",
     )
+
+    tasks = {
+        stroke: asyncio.create_task(
+            stats_service.get_turn_analytics(athlete_id, stroke)
+        )
+        for stroke in _SUPPORTED_TURN_STROKES
+    }
+    turn_sections: list[str] = []
+    for stroke, task in tasks.items():
+        try:
+            analytics = await task
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Failed to load turn analytics for %s: %s", stroke, exc)
+            continue
+        progress = analytics.get("progress", ())
+        if not progress:
+            continue
+        turn_sections.append(_format_turn_summary(stroke, progress))
+    if turn_sections:
+        await target.answer("\n\n".join(turn_sections), parse_mode="HTML")
     if isinstance(event, types.CallbackQuery):
         await event.answer()
 
 
 @router.message(Command("progress"))
-async def cmd_progress(message: types.Message, role_service: RoleService) -> None:
+async def cmd_progress(
+    message: types.Message, role_service: RoleService, stats_service: StatsService
+) -> None:
     """Ask to choose athlete for progress visualization."""
 
     await role_service.upsert_user(message.from_user)
     role = await role_service.get_role(message.from_user.id)
     if role == ROLE_ATHLETE:
-        await _send_progress_report(message, message.from_user.id)
+        await _send_progress_report(message, message.from_user.id, stats_service)
         return
 
     try:
@@ -259,7 +491,9 @@ async def cmd_progress(message: types.Message, role_service: RoleService) -> Non
 
 
 @router.callback_query(F.data.startswith("progress_select_"))
-async def show_progress(cb: types.CallbackQuery, role_service: RoleService) -> None:
+async def show_progress(
+    cb: types.CallbackQuery, role_service: RoleService, stats_service: StatsService
+) -> None:
     """Generate progress visualization for selected athlete."""
 
     try:
@@ -272,4 +506,132 @@ async def show_progress(cb: types.CallbackQuery, role_service: RoleService) -> N
         await cb.answer("Немає доступу до цього спортсмена.", show_alert=True)
         return
 
-    await _send_progress_report(cb, athlete_id)
+    await _send_progress_report(cb, athlete_id, stats_service)
+
+
+def _parse_turn_command(message: types.Message) -> tuple[str | None, int | None]:
+    """Parse stroke and optional athlete id from the command."""
+
+    text = (message.text or "").strip()
+    parts = text.split()
+    stroke = None
+    athlete_id = None
+    if len(parts) >= 2:
+        stroke = _normalize_stroke(parts[1])
+    if len(parts) >= 3:
+        try:
+            athlete_id = int(parts[2])
+        except ValueError:
+            athlete_id = None
+    return stroke, athlete_id
+
+
+@router.message(Command("turn_analysis"))
+async def cmd_turn_analysis(
+    message: types.Message,
+    stats_service: StatsService,
+    role_service: RoleService,
+) -> None:
+    """Provide detailed turn analytics with visualisations."""
+
+    user = message.from_user
+    if user is None:
+        await message.answer("Команда доступна лише для зареєстрованих користувачів.")
+        return
+    stroke_arg, requested_id = _parse_turn_command(message)
+    stroke = stroke_arg or "breaststroke"
+    if stroke not in _SUPPORTED_TURN_STROKES:
+        await message.answer(
+            "Доступні стилі: breaststroke, butterfly. Приклад: /turn_analysis butterfly"
+        )
+        return
+
+    role = await role_service.get_role(user.id)
+    if role == ROLE_ATHLETE:
+        athlete_id = user.id
+    else:
+        if requested_id is None:
+            await message.answer(
+                "Вкажіть ID спортсмена: /turn_analysis butterfly 123456"
+            )
+            return
+        athlete_id = requested_id
+        if not await role_service.can_access_athlete(user.id, athlete_id):
+            await message.answer("Немає доступу до цього спортсмена.")
+            return
+
+    status_msg = await message.answer("Готую аналітику поворотів…")
+    try:
+        analytics = await stats_service.get_turn_analytics(athlete_id, stroke)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.error("Failed to load turn analytics: %s", exc, exc_info=True)
+        await status_msg.edit_text("Не вдалося отримати дані аналізу поворотів.")
+        return
+    rows = analytics.get("rows", ())
+    if not rows:
+        await status_msg.edit_text("Поки немає поворотів для аналізу цього стилю.")
+        return
+
+    sessions = _group_turn_sessions(rows)
+    athlete_name = rows[0].get("athlete_name") if rows else ""
+
+    plots = [
+        (
+            _build_turn_efficiency_plot,
+            "turn_efficiency.png",
+            "Середній час повороту за тренуваннями",
+        ),
+        (
+            _build_turn_comparison_plot,
+            "turn_comparison.png",
+            "Порівняння поворотів в останньому запливі",
+        ),
+        (
+            _build_turn_heatmap,
+            "turn_heatmap.png",
+            "Теплова карта ефективності",
+        ),
+    ]
+    await status_msg.edit_text("Аналітика готова. Надсилаю графіки…")
+    for builder, filename, caption in plots:
+        try:
+            image = builder(sessions, athlete_name, stroke)
+        except Exception as exc:  # pragma: no cover - plotting guard
+            logger.warning("Failed to render %s: %s", filename, exc)
+            continue
+        if not image:
+            continue
+        await message.answer_photo(
+            BufferedInputFile(image, filename=filename),
+            caption=caption,
+        )
+
+    summary = analytics.get("progress", ())
+    if summary:
+        await message.answer(
+            _format_turn_summary(stroke, summary),
+            parse_mode="HTML",
+        )
+    try:
+        comparison = await stats_service.compare_turn_efficiency(
+            athlete_id, StatsPeriod.WEEK
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.warning("Failed to compute turn comparison: %s", exc)
+        return
+    comparisons = comparison.get("comparisons", ())
+    if comparisons:
+        lines = ["<b>Порівняння із попереднім тижнем</b>"]
+        for item in comparisons:
+            if item.delta is None:
+                continue
+            percent = item.percent_change
+            lines.append(
+                "• Поворот #{num}: {delta:+.2f} c ({percent:+.1f}%)".format(
+                    num=item.turn_number,
+                    delta=item.delta,
+                    percent=percent if percent is not None else 0.0,
+                )
+            )
+        if len(lines) > 1:
+            await message.answer("\n".join(lines), parse_mode="HTML")


### PR DESCRIPTION
## Summary
- extend the statistics service with turn analytics data classes and helpers for trend and comparison reporting
- add turn analysis visualisations, reporting helpers, and integrate summaries into the existing /progress flow
- introduce the /turn_analysis command that generates plots and weekly comparisons for supported strokes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e1aa29a43083258f675ec1bb189a24