### PR TITLE
Add turn analytics and wizard tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
+"""Common fixtures shared by turn analytics test modules."""
 
+import importlib
 import os
 import sys
 from datetime import datetime, timedelta, timezone
@@ -12,9 +13,9 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from services.turn_service import TurnService
-
 os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
+
+TurnService = importlib.import_module("services.turn_service").TurnService
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,52 @@ from __future__ import annotations
 
 import os
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-os.environ.setdefault("BOT_TOKEN", "test-token")
+from services.turn_service import TurnService
+
+os.environ.setdefault("BOT_TOKEN", "123456:TESTTOKEN")
+
+
+@pytest.fixture
+def sample_turn_rows() -> list[dict]:
+    """Return synthetic turn analysis rows for plotting and analytics tests."""
+
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    rows: list[dict] = []
+    result_ids = (101, 102)
+    offsets = (timedelta(days=0), timedelta(days=1))
+    for result_id, offset in zip(result_ids, offsets):
+        timestamp = base_time + offset
+        for turn_number, total in enumerate((5.2, 4.8), start=1):
+            rows.append(
+                {
+                    "result_id": result_id,
+                    "timestamp": timestamp,
+                    "distance": 100,
+                    "stroke": "breaststroke",
+                    "athlete_name": "Test Swimmer",
+                    "turn_number": turn_number,
+                    "approach_time": 3.9,
+                    "wall_contact_time": 0.75,
+                    "push_off_time": 0.95,
+                    "underwater_time": 3.0,
+                    "total_turn_time": total + turn_number * 0.1,
+                }
+            )
+    return rows
+
+
+@pytest.fixture
+def mock_turn_service() -> AsyncMock:
+    """Return AsyncMock-based mock for :class:`TurnService`."""
+
+    return AsyncMock(spec=TurnService)

--- a/tests/test_turn_analytics.py
+++ b/tests/test_turn_analytics.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sqlite3
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+stats_spec = importlib.util.spec_from_file_location(
+    "services.stats_service", PROJECT_ROOT / "services" / "stats_service.py"
+)
+stats_module = importlib.util.module_from_spec(stats_spec)
+assert stats_spec.loader is not None
+stats_spec.loader.exec_module(stats_module)
+
+services_stub = types.ModuleType("services")
+services_stub.__path__ = [str(PROJECT_ROOT / "services")]
+services_stub.ws_athletes = SimpleNamespace(get_all_values=lambda: [])
+services_stub.ws_results = SimpleNamespace(get_all_values=lambda: [])
+sys.modules["services"] = services_stub
+sys.modules["services.stats_service"] = stats_module
+
+from handlers.progress import (
+    _build_turn_comparison_plot,
+    _build_turn_efficiency_plot,
+    _build_turn_heatmap,
+    _format_turn_summary,
+    _group_turn_sessions,
+)
+from services.stats_service import StatsPeriod, StatsService, TurnProgressResult
+
+
+def test_stats_service_turn_analytics_queries(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        db_dir = tmp_path / "turns"
+        db_dir.mkdir(parents=True, exist_ok=True)
+        db_path = db_dir / "stats.db"
+        service = StatsService(db_path)
+        await service.init()
+
+        now = datetime.now(timezone.utc)
+        previous_ts = (now - timedelta(days=8)).isoformat()
+        current_ts = (now - timedelta(days=2)).isoformat()
+        latest_ts = (now - timedelta(days=1)).isoformat()
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS turn_analysis (
+                    id INTEGER PRIMARY KEY,
+                    result_id INTEGER NOT NULL,
+                    turn_number INTEGER NOT NULL,
+                    approach_time REAL,
+                    wall_contact_time REAL,
+                    push_off_time REAL,
+                    underwater_time REAL,
+                    total_turn_time REAL
+                )
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO results (athlete_id, athlete_name, stroke, distance, total_seconds, timestamp, is_pr)
+                VALUES (?,?,?,?,?,?,?)
+                """,
+                (1, "Test Swimmer", "breaststroke", 100, 70.0, previous_ts, 0),
+            )
+            conn.execute(
+                """
+                INSERT INTO results (athlete_id, athlete_name, stroke, distance, total_seconds, timestamp, is_pr)
+                VALUES (?,?,?,?,?,?,?)
+                """,
+                (1, "Test Swimmer", "breaststroke", 100, 69.0, current_ts, 1),
+            )
+            conn.execute(
+                """
+                INSERT INTO results (athlete_id, athlete_name, stroke, distance, total_seconds, timestamp, is_pr)
+                VALUES (?,?,?,?,?,?,?)
+                """,
+                (1, "Test Swimmer", "breaststroke", 100, 68.5, latest_ts, 1),
+            )
+            result_ids = [
+                row[0]
+                for row in conn.execute("SELECT id FROM results ORDER BY timestamp")
+            ]
+            turn_payload = [
+                (result_ids[0], 1, 3.9, 0.75, 0.95, 3.0, 5.2),
+                (result_ids[0], 2, 3.9, 0.75, 0.95, 3.0, 6.3),
+                (result_ids[1], 1, 3.8, 0.7, 0.9, 2.8, 4.8),
+                (result_ids[1], 2, 3.8, 0.7, 0.9, 2.8, 6.0),
+                (result_ids[2], 1, 3.7, 0.68, 0.88, 2.7, 4.6),
+                (result_ids[2], 2, 3.7, 0.68, 0.88, 2.7, 5.8),
+            ]
+            conn.executemany(
+                """
+                INSERT INTO turn_analysis (
+                    result_id, turn_number, approach_time, wall_contact_time, push_off_time,
+                    underwater_time, total_turn_time
+                ) VALUES (?,?,?,?,?,?,?)
+                """,
+                turn_payload,
+            )
+            conn.commit()
+
+        analytics = await service.get_turn_analytics(1, "breaststroke")
+        rows = analytics["rows"]
+        assert len(rows) == 6
+        assert rows[0]["turn_number"] == 1
+        assert rows[0]["timestamp"] <= rows[-1]["timestamp"]
+
+        progress = analytics["progress"]
+        assert len(progress) == 2
+        first_turn = next(item for item in progress if item.turn_number == 1)
+        assert first_turn.improvement_rate == pytest.approx(
+            (5.2 - 4.6) / 5.2 * 100, rel=1e-3
+        )
+        assert first_turn.efficiency_trend < 0
+
+        comparison = await service.compare_turn_efficiency(1, StatsPeriod.WEEK)
+        assert comparison["previous"][1] == pytest.approx(5.2)
+        assert comparison["current"][1] == pytest.approx((4.8 + 4.6) / 2, rel=1e-3)
+        turn1 = next(
+            item for item in comparison["comparisons"] if item.turn_number == 1
+        )
+        assert turn1.delta == pytest.approx(0.5, rel=1e-3)
+        assert turn1.percent_change == pytest.approx(0.5 / 5.2 * 100, rel=1e-3)
+
+        summary = _format_turn_summary("breaststroke", progress)
+        assert summary.startswith("<b>")
+        assert "#1" in summary
+
+    asyncio.run(scenario())
+
+
+def test_grouping_and_plots_produce_png(sample_turn_rows: list[dict]) -> None:
+    sessions = _group_turn_sessions(sample_turn_rows)
+    assert len(sessions) == 2
+    assert sessions[0]["turns"][0]["turn_number"] == 1
+    athlete_name = sample_turn_rows[0]["athlete_name"]
+
+    efficiency_plot = _build_turn_efficiency_plot(
+        sessions, athlete_name, "breaststroke"
+    )
+    comparison_plot = _build_turn_comparison_plot(
+        sessions, athlete_name, "breaststroke"
+    )
+    heatmap_plot = _build_turn_heatmap(sessions, athlete_name, "breaststroke")
+
+    for image in (efficiency_plot, comparison_plot, heatmap_plot):
+        assert image is not None
+        assert image.startswith(b"\x89PNG")
+
+    custom_progress = (
+        TurnProgressResult(turn_number=1, efficiency_trend=-0.1, improvement_rate=5.0),
+        TurnProgressResult(turn_number=2, efficiency_trend=0.2, improvement_rate=-3.0),
+    )
+    summary = _format_turn_summary("butterfly", custom_progress)
+    assert summary.startswith("<b>")
+    assert "#2" in summary

--- a/tests/test_turn_i18n.py
+++ b/tests/test_turn_i18n.py
@@ -1,0 +1,66 @@
+import pytest
+
+import i18n
+from i18n import t
+
+TURN_KEYS = [
+    "add.step.turns",
+    "add.summary",
+    "turn.entry.title",
+    "turn.entry.button",
+    "turn.analysis.button",
+    "turn.analysis.efficiency",
+    "turn.recommendation.button",
+    "turn.recommendation.breaststroke",
+    "turn.recommendation.butterfly",
+]
+
+
+@pytest.mark.parametrize("key", TURN_KEYS)
+def test_turn_translation_keys_present(key: str) -> None:
+    for lang in ("uk", "ru"):
+        assert key in i18n._LOCALE_DATA[lang]
+
+
+def test_turn_entry_translations() -> None:
+    ru_template = i18n._LOCALE_DATA["ru"]["turn.entry.button"]
+    uk_template = i18n._LOCALE_DATA["uk"]["turn.entry.button"]
+    assert t("turn.entry.button", lang="ru", number=2) == ru_template.format(number=2)
+    assert t("turn.entry.button", lang="uk", number=2) == uk_template.format(number=2)
+
+
+def test_turn_summary_translation_formatting() -> None:
+    ru_template = i18n._LOCALE_DATA["ru"]["add.summary"]
+    uk_template = i18n._LOCALE_DATA["uk"]["add.summary"]
+    expected_args = dict(
+        style="breaststroke",
+        distance=100,
+        segments="25m + turn",
+        splits="0:30 0:31",
+        turns="--",
+        total="1:02.00",
+    )
+    expected_ru = ru_template.replace("\\n", "\n").format(**expected_args)
+    assert t("add.summary", lang="ru", **expected_args) == expected_ru
+
+    uk_args = dict(
+        style="bat",
+        distance=100,
+        segments="25m + turn",
+        splits="0:30 0:31",
+        turns="--",
+        total="1:02.00",
+    )
+    expected_uk = uk_template.replace("\\n", "\n").format(**uk_args)
+    assert t("add.summary", lang="uk", **uk_args) == expected_uk
+
+
+def test_turn_recommendation_translations() -> None:
+    assert (
+        t("turn.recommendation.breaststroke", lang="ru")
+        == i18n._LOCALE_DATA["ru"]["turn.recommendation.breaststroke"]
+    )
+    assert (
+        t("turn.recommendation.butterfly", lang="uk")
+        == i18n._LOCALE_DATA["uk"]["turn.recommendation.butterfly"]
+    )

--- a/tests/test_turn_service.py
+++ b/tests/test_turn_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from services.turn_service import TurnMetrics, TurnService
+
+
+def test_analyze_turn_metrics_and_efficiency() -> None:
+    async def scenario() -> None:
+        service = TurnService()
+        metrics = await service.analyze_turn("Freestyle", [3.4, 0.55, 0.75, 3.6])
+
+        assert metrics.approach_time == pytest.approx(3.4)
+        assert metrics.wall_contact_time == pytest.approx(0.55)
+        assert metrics.push_off_time == pytest.approx(0.75)
+        assert metrics.underwater_time == pytest.approx(3.6)
+        assert metrics.efficiency_score == pytest.approx(100.0)
+
+    asyncio.run(scenario())
+
+
+def test_turn_recommendations_for_strokes() -> None:
+    async def scenario() -> None:
+        service = TurnService()
+
+        breast_metrics = TurnMetrics(
+            approach_time=5.0,
+            wall_contact_time=0.5,
+            push_off_time=1.1,
+            underwater_time=1.5,
+            efficiency_score=0.0,
+        )
+        breast_recs = await service.get_turn_recommendations(
+            "breaststroke", breast_metrics
+        )
+
+        assert "Hold speed into the wall" in breast_recs
+        assert "two-hand touch" in breast_recs
+        assert "Use one powerful breaststroke kick" in breast_recs
+
+        fly_metrics = TurnMetrics(
+            approach_time=4.5,
+            wall_contact_time=0.4,
+            push_off_time=1.1,
+            underwater_time=2.5,
+            efficiency_score=0.0,
+        )
+        fly_recs = await service.get_turn_recommendations("butterfly", fly_metrics)
+
+        assert "two-hand touch" in fly_recs
+        assert "dolphin kicks" in fly_recs
+
+    asyncio.run(scenario())
+
+
+def test_analyze_turn_requires_complete_segments() -> None:
+    async def scenario() -> None:
+        service = TurnService()
+        with pytest.raises(ValueError):
+            await service.analyze_turn("freestyle", [3.0, 0.5])
+
+    asyncio.run(scenario())
+
+
+def test_calculate_efficiency_without_stroke_association() -> None:
+    async def scenario() -> None:
+        service = TurnService()
+        metrics = TurnMetrics(
+            approach_time=3.0,
+            wall_contact_time=0.5,
+            push_off_time=0.7,
+            underwater_time=3.0,
+            efficiency_score=0.0,
+        )
+        with pytest.raises(ValueError):
+            await service.calculate_turn_efficiency(metrics)
+
+    asyncio.run(scenario())
+
+
+def test_unknown_stroke_rejected() -> None:
+    async def scenario() -> None:
+        service = TurnService()
+        metrics = TurnMetrics(
+            approach_time=3.5,
+            wall_contact_time=0.6,
+            push_off_time=0.8,
+            underwater_time=3.5,
+            efficiency_score=0.0,
+        )
+        with pytest.raises(ValueError):
+            await service.get_turn_recommendations("sidestroke", metrics)
+
+    asyncio.run(scenario())

--- a/tests/test_turn_wizard.py
+++ b/tests/test_turn_wizard.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.base import StorageKey
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from handlers.add_wizard import (
+    AddWizardStates,
+    _encode_template_payload,
+    _generate_segment_templates,
+    choose_distance,
+    choose_style,
+    choose_template,
+    input_splits,
+    input_turn_details,
+    start_wizard,
+)
+from i18n import t
+from keyboards import AddWizardCB
+
+
+class DummyMessage:
+    def __init__(self, text: str = "", user_id: int = 42, chat_id: int = 24) -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=user_id)
+        self.chat = SimpleNamespace(id=chat_id)
+        self.answer = AsyncMock()
+
+
+class DummyCallback:
+    def __init__(self, message: DummyMessage) -> None:
+        self.message = message
+        self.from_user = message.from_user
+        self.data = ""
+        self.answer = AsyncMock()
+
+
+def _make_state() -> FSMContext:
+    storage = MemoryStorage()
+    key = StorageKey(bot_id=1, chat_id=24, user_id=42)
+    return FSMContext(storage=storage, key=key)
+
+
+def test_turn_state_triggered_for_breaststroke_template() -> None:
+    async def scenario() -> None:
+        state = _make_state()
+        start_msg = DummyMessage()
+        await start_wizard(start_msg, state)
+
+        style_cb = DummyCallback(start_msg)
+        await choose_style(
+            style_cb,
+            state,
+            AddWizardCB(action="style", value="STROKE_BREASTSTROKE"),
+        )
+
+        distance_cb = DummyCallback(start_msg)
+        await choose_distance(
+            distance_cb,
+            state,
+            AddWizardCB(action="distance", value="100"),
+        )
+
+        templates = _generate_segment_templates(100, "breaststroke")
+        turn_template = templates[0]
+        payload = _encode_template_payload(turn_template)
+
+        template_cb = DummyCallback(start_msg)
+        await choose_template(
+            template_cb,
+            state,
+            AddWizardCB(action="template", value=payload),
+        )
+        assert await state.get_state() == AddWizardStates.enter_splits.state
+
+        splits_msg = DummyMessage("0:30 0:31 0:30 0:32")
+        await input_splits(splits_msg, state)
+        assert await state.get_state() == AddWizardStates.enter_turn_details.state
+        prompt = splits_msg.answer.await_args[0][0]
+        expected_prompt = t("add.step.turns", count=3)
+        assert prompt == expected_prompt
+
+    asyncio.run(scenario())
+
+
+def test_turn_templates_include_turn_labels() -> None:
+    async def scenario() -> None:
+        templates = _generate_segment_templates(100, "butterfly")
+        assert templates[0].segment_types.count("turn") == 3
+
+        freestyle_templates = _generate_segment_templates(100, "freestyle")
+        assert freestyle_templates[0].segment_types.count("turn") == 0
+
+    asyncio.run(scenario())
+
+
+def test_input_turn_details_validation_flow() -> None:
+    async def scenario() -> None:
+        state = _make_state()
+        await state.update_data(
+            style="butterfly",
+            segment_types=("swim", "turn", "swim", "turn"),
+        )
+        await state.set_state(AddWizardStates.enter_turn_details)
+
+        bad_format_msg = DummyMessage("oops")
+        await input_turn_details(bad_format_msg, state)
+        assert bad_format_msg.answer.await_args[0][0] == t("error.invalid_time")
+
+        mismatch_msg = DummyMessage("0:03")
+        await input_turn_details(mismatch_msg, state)
+        assert await state.get_state() == AddWizardStates.enter_turn_details.state
+
+        valid_msg = DummyMessage("0:03 0:04")
+        await input_turn_details(valid_msg, state)
+        assert await state.get_state() == AddWizardStates.enter_total.state
+        total_prompt = valid_msg.answer.await_args[0][0]
+        assert total_prompt == t("add.step.total")
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- add reusable fixtures for turn analysis data and mocked turn service
- cover TurnService edge cases and recommendations with new tests
- validate wizard flow, analytics reporting, and i18n translations for turn features

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1acea7808832595d43a1f69737526