### PR TITLE
Add AWS SDK dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ google-auth==2.22.0
 python-dotenv==1.0.1
 matplotlib==3.8.2
 sentry-sdk==1.40.6
+boto3==1.34.106
+botocore==1.34.106


### PR DESCRIPTION
## Summary
- add boto3 and botocore pins to the dependency list so the backup service can access AWS S3

## Testing
- pip install -r requirements.txt *(fails: proxy blocks access to pypi for boto3)*
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68e1c29b9524832595e3a9cd6ad232d6