### PR TITLE
Update entrypoint script to initialize environment before starting bot

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,23 @@
-#!/bin/sh
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-exec python bot.py
+if [ ! -f .env ]; then
+  if [ -f .env.example ]; then
+    cp .env.example .env
+  else
+    echo "Error: .env.example not found" >&2
+    exit 1
+  fi
+fi
+
+set -a
+. ./.env
+set +a
+
+if [ -z "${BOT_TOKEN:-}" ]; then
+  echo "Error: BOT_TOKEN not set"
+  exit 1
+fi
+
+python db.py
+python bot.py


### PR DESCRIPTION
## Summary
- ensure a .env file exists by copying from .env.example when missing
- load environment variables, validate BOT_TOKEN, and initialise the database schema before starting the bot

## Testing
- pip install -r requirements.txt *(fails: ProxyError - Tunnel connection failed: 403 Forbidden)*
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1c48f3c7883258d2b14b665ff4c9a