### PR TITLE
Update environment example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,35 @@
-# Telegram bot token
-BOT_TOKEN=
+# Токен бота
+BOT_TOKEN=""
 
-# Comma-separated list of admin Telegram IDs
-ADMIN_IDS=
+# ID администраторов через запятую
+ADMIN_IDS="123,456"
 
-# Path to service account credentials file for Google Sheets
-CREDENTIALS_FILE=creds.json
+# DSN для интеграции с Sentry
+SENTRY_DSN=""
 
-# Spreadsheet key for Google Sheets integration
-SPREADSHEET_KEY=
+# Период тихих часов (формат HH:MM-HH:MM)
+QUIET_HOURS="22:00-07:00"
 
-# Quiet hours in HH:MM-HH:MM format (e.g., 22:00-07:00)
-QUIET_HOURS=
+# Интервал опроса очереди уведомлений в тихие часы (в минутах)
+QUIET_QUEUE_INTERVAL="60"
 
-# Optional Sentry DSN
-SENTRY_DSN=
+# Часовой пояс для тихих часов
+QUIET_HOURS_TZ="Europe/Kyiv"
 
-# Timezone for container
-TZ=Europe/Kyiv
+# Имя S3-бакета для резервных копий
+S3_BACKUP_BUCKET=""
 
-# Default stroke for /turn_analysis command (breaststroke or butterfly)
-TURN_ANALYSIS_DEFAULT_STROKE=breaststroke
+# Префикс ключей резервных копий в S3
+S3_BACKUP_PREFIX="sprint-bot/backups/"
+
+# Интервал между резервными копиями (в часах)
+BACKUP_INTERVAL_HOURS="6"
+
+# Класс хранения в S3
+S3_STORAGE_CLASS=""
+
+# Пользовательская конечная точка S3
+S3_ENDPOINT_URL=""
+
+# Текущее окружение запуска бота
+ENV="production"


### PR DESCRIPTION
## Summary
- refresh `.env.example` with localized descriptions and example defaults for bot, quiet hours, and S3 settings

## Testing
- ❌ `pip install -r requirements.txt` (fails: proxy returned 403 Forbidden for boto3)
- ✅ `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e1c54c4db8832590cb7149aa3dcc4c