### PR TITLE
Inject StatsService into menu progress redirect

### DIFF
--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -16,6 +16,7 @@ from menu_callbacks import (
     CB_MENU_TEMPLATES,
 )
 from role_service import ROLE_ADMIN, ROLE_ATHLETE, ROLE_TRAINER, RoleService
+from services.stats_service import StatsService
 from utils.roles import require_roles
 
 router = Router()
@@ -134,11 +135,11 @@ async def menu_reports(cb: types.CallbackQuery) -> None:
 
 @router.callback_query(F.data == CB_MENU_PROGRESS)
 async def menu_progress_redirect(
-    cb: types.CallbackQuery, role_service: RoleService
+    cb: types.CallbackQuery, role_service: RoleService, stats_service: StatsService
 ) -> None:
     """Redirect progress menu button to the existing progress flow."""
 
     from handlers.progress import cmd_progress
 
-    await cmd_progress(cb.message, role_service)
+    await cmd_progress(cb.message, role_service, stats_service)
     await cb.answer()

--- a/tests/test_menu_progress.py
+++ b/tests/test_menu_progress.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import ModuleType, SimpleNamespace
+
+from handlers import menu
+
+
+class _DummyCallback:
+    def __init__(self, message: object) -> None:
+        self.message = message
+        self.answered = False
+
+    async def answer(self) -> None:
+        self.answered = True
+
+
+def test_menu_progress_redirect_forwards_stats_service(monkeypatch) -> None:
+    calls: list[tuple[object, object, object]] = []
+
+    async def fake_cmd_progress(
+        message: object, role_service: object, stats_service: object
+    ) -> None:
+        calls.append((message, role_service, stats_service))
+
+    fake_progress_module = ModuleType("handlers.progress")
+    fake_progress_module.cmd_progress = fake_cmd_progress
+    monkeypatch.setitem(sys.modules, "handlers.progress", fake_progress_module)
+
+    role_service = SimpleNamespace()
+    stats_service = SimpleNamespace()
+    callback = _DummyCallback(message=SimpleNamespace())
+
+    asyncio.run(menu.menu_progress_redirect(callback, role_service, stats_service))
+
+    assert calls == [(callback.message, role_service, stats_service)]
+    assert callback.answered


### PR DESCRIPTION
## Summary
- inject `StatsService` into the menu progress redirect handler and forward it to `cmd_progress`
- add a unit test covering the redirect to ensure the progress command receives the stats service

## Testing
- pip install -r requirements.txt
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e458e2d6708325a1e2fe7b61e7dd17