### PR TITLE
Support injected S3 client factory in backup service

### DIFF
--- a/tests/test_backup_service.py
+++ b/tests/test_backup_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import backup_service
+from backup_service import BackupService
+
+
+def test_backup_service_prefers_provided_client_factory(tmp_path, monkeypatch):
+    factory_client = object()
+    factory = MagicMock(return_value=factory_client)
+
+    session_mock = MagicMock(
+        side_effect=AssertionError("Session should not be constructed")
+    )
+    monkeypatch.setattr(backup_service.boto3.session, "Session", session_mock)
+
+    service = BackupService(
+        bot=MagicMock(),
+        db_path=tmp_path / "bot.sqlite3",
+        bucket_name="bucket",
+        client_factory=factory,
+    )
+
+    first_client = service._get_client()
+    second_client = service._get_client()
+
+    assert first_client is factory_client
+    assert second_client is factory_client
+    factory.assert_called_once_with()
+    session_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- allow BackupService to accept an optional client factory for constructing S3 clients
- reuse the injected factory when resolving the client instead of creating a new boto3 session
- add unit coverage confirming the factory is preferred

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e45f65e7488325846835b38b9233bd