### PR TITLE
Add rotating log handler coverage for get_logger

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,35 +1,87 @@
 import json
+import logging
+from uuid import uuid4
 
+import utils.logger as logger_module
 from utils.logger import get_logger
 
 
-def test_logger_emits_valid_json_lines(capfd) -> None:
-    logger = get_logger("tests.logger.json")
+def test_logger_writes_json_to_rotating_file_and_stderr(
+    tmp_path, monkeypatch, capfd
+) -> None:
+    monkeypatch.setattr(logger_module, "LOG_DIR", tmp_path)
+
+    logger_name = f"tests.logger.{uuid4()}"
+    logger = get_logger(logger_name)
+
+    duplicate_logger = get_logger(logger_name)
+    assert logger is duplicate_logger
+
+    handlers = logger.handlers
+    assert len(handlers) == 2
+    assert (
+        sum(getattr(handler, "_is_sprint_json_stream", False) for handler in handlers)
+        == 1
+    )
+    assert (
+        sum(getattr(handler, "_is_sprint_json_file", False) for handler in handlers)
+        == 1
+    )
 
     logger.info("hello %s", "world")
+    logger.warning("heads up", extra={"user_id": 7})
     logger.error(
         "boom",
         extra={"user_id": 42, "cmd": "/start", "latency_ms": 123},
     )
 
+    for handler in handlers:
+        if hasattr(handler, "flush"):
+            handler.flush()
+
     captured = capfd.readouterr()
-    output = "".join(part for part in (captured.err, captured.out) if part)
-    lines = [line for line in output.splitlines() if line.strip()]
+    assert not captured.out
 
-    assert len(lines) == 2, f"expected two log lines, got {lines!r}"
+    err_lines = [line for line in captured.err.splitlines() if line.strip()]
+    assert len(err_lines) == 2
 
-    first_payload = json.loads(lines[0])
-    second_payload = json.loads(lines[1])
+    warning_payload = json.loads(err_lines[0])
+    error_payload = json.loads(err_lines[1])
 
-    for payload in (first_payload, second_payload):
+    assert warning_payload["msg"] == "heads up"
+    assert warning_payload["level"] == "WARNING"
+    assert warning_payload["user_id"] == 7
+
+    assert error_payload["msg"] == "boom"
+    assert error_payload["level"] == "ERROR"
+    assert error_payload["user_id"] == 42
+    assert error_payload["cmd"] == "/start"
+    assert error_payload["latency_ms"] == 123
+
+    log_file = tmp_path / "bot.log"
+    assert log_file.exists()
+
+    file_lines = [
+        json.loads(line)
+        for line in log_file.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(file_lines) == 3
+
+    info_payload, warning_file_payload, error_file_payload = file_lines
+
+    for payload in (info_payload, warning_file_payload, error_file_payload):
         for key in ("ts", "level", "msg"):
             assert key in payload
 
-    assert first_payload["msg"] == "hello world"
-    assert first_payload["level"] == "INFO"
+    assert info_payload["msg"] == "hello world"
+    assert info_payload["level"] == "INFO"
 
-    assert second_payload["msg"] == "boom"
-    assert second_payload["level"] == "ERROR"
-    assert second_payload["user_id"] == 42
-    assert second_payload["cmd"] == "/start"
-    assert second_payload["latency_ms"] == 123
+    assert warning_file_payload == warning_payload
+    assert error_file_payload == error_payload
+
+    # Clean up handlers to avoid influencing other tests.
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+    logging.getLogger(logger_name).handlers.clear()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -4,10 +4,18 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 from typing import Any
 
 __all__ = ["get_logger"]
+
+LOG_DIR = Path("logs")
+LOG_FILE_NAME = "bot.log"
+LOG_MAX_BYTES = 5 * 1024 * 1024
+LOG_BACKUP_COUNT = 3
 
 
 class JsonLogFormatter(logging.Formatter):
@@ -25,15 +33,50 @@ class JsonLogFormatter(logging.Formatter):
         return json.dumps(payload, ensure_ascii=False)
 
 
+def _ensure_log_dir() -> Path:
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    return LOG_DIR
+
+
+def _configure_file_handler() -> logging.Handler:
+    log_dir = _ensure_log_dir()
+    handler = RotatingFileHandler(
+        log_dir / LOG_FILE_NAME,
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(JsonLogFormatter())
+    handler._is_sprint_json = True  # type: ignore[attr-defined]
+    handler._is_sprint_json_file = True  # type: ignore[attr-defined]
+    return handler
+
+
+def _configure_stream_handler() -> logging.Handler:
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setLevel(logging.WARNING)
+    handler.setFormatter(JsonLogFormatter())
+    handler._is_sprint_json = True  # type: ignore[attr-defined]
+    handler._is_sprint_json_stream = True  # type: ignore[attr-defined]
+    return handler
+
+
 def get_logger(name: str) -> logging.Logger:
-    """Return logger configured with JSON ``StreamHandler`` output."""
+    """Return logger configured with JSON file/stream handlers."""
 
     logger = logging.getLogger(name)
-    if not any(getattr(handler, "_is_sprint_json", False) for handler in logger.handlers):
-        handler = logging.StreamHandler()
-        handler.setFormatter(JsonLogFormatter())
-        handler._is_sprint_json = True  # type: ignore[attr-defined]
-        logger.addHandler(handler)
+
+    if not any(
+        getattr(handler, "_is_sprint_json_stream", False) for handler in logger.handlers
+    ):
+        logger.addHandler(_configure_stream_handler())
+
+    if not any(
+        getattr(handler, "_is_sprint_json_file", False) for handler in logger.handlers
+    ):
+        logger.addHandler(_configure_file_handler())
+
     logger.setLevel(logging.INFO)
     logger.propagate = False
     return logger


### PR DESCRIPTION
## Summary
- add RotatingFileHandler configuration to utils.logger.get_logger alongside stderr JSON stream output
- ensure log directory creation and handler deduplication while preserving JSON formatting
- expand logger tests to verify file/stream behaviour, handler deduplication, and temporary log directory usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e46b652a3c832597ca48cde25f6742