### PR TITLE
Add lazy bot accessor for aiogram instance

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -220,7 +220,7 @@ async def main() -> None:
     from middlewares.roles import RoleMiddleware
     from notifications import NotificationService
     from role_service import RoleService
-    from services import ADMIN_IDS, TurnService, bot
+    from services import ADMIN_IDS, TurnService, get_bot
     from services.audit_service import AuditService
     from services.io_service import IOService
     from services.query_service import QueryService
@@ -228,6 +228,7 @@ async def main() -> None:
     from services.user_service import UserService
     from template_service import TemplateService
 
+    bot = get_bot()
     turn_service = TurnService()
     notification_service = NotificationService(bot=bot)
     chat_service = ChatService()

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -12,7 +12,7 @@ from aiogram.fsm.state import State, StatesGroup
 from handlers.menu import build_menu_keyboard
 from menu_callbacks import CB_MENU_INVITE
 from role_service import ROLE_ATHLETE, ROLE_TRAINER, RoleService
-from services import bot, ws_athletes
+from services import get_bot, ws_athletes
 from utils.roles import require_roles
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ async def send_invite(cb: types.CallbackQuery, role_service: RoleService) -> Non
     await role_service.upsert_user(cb.from_user, default_role=ROLE_TRAINER)
     code = secrets.token_hex(4)
     active_invites[code] = cb.from_user.id
+    bot = get_bot()
     me = await bot.get_me()
     link = f"https://t.me/{me.username}?start=\u0440\u0435\u0433_{code}"
 

--- a/services/base.py
+++ b/services/base.py
@@ -16,10 +16,18 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 
 # --- Bot Initialization ---
-TOKEN = os.getenv("BOT_TOKEN")
-if not TOKEN:
-    raise ValueError("BOT_TOKEN must be set in .env file")
-bot = Bot(token=TOKEN, parse_mode="HTML")
+
+
+@lru_cache(maxsize=1)
+def get_bot() -> Bot:
+    """Return a cached aiogram Bot instance configured for the project."""
+
+    token = os.getenv("BOT_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError(
+            "BOT_TOKEN environment variable must be set and non-empty to create the bot."
+        )
+    return Bot(token=token, parse_mode="HTML")
 
 
 # --- Google Sheets Setup ---


### PR DESCRIPTION
## Summary
- add a cached `get_bot` helper that validates `BOT_TOKEN` before creating the aiogram client
- update bot startup and registration handler code to resolve the bot instance through `get_bot`

## Testing
- pip install -r requirements.txt
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4e1f1bf448325998948e6506daab8