### PR TITLE
Refactor Google Sheets access to lazy helpers

### DIFF
--- a/handlers/common.py
+++ b/handlers/common.py
@@ -7,7 +7,7 @@ from aiogram.filters import Command
 from aiogram.types import KeyboardButton, ReplyKeyboardMarkup
 
 from role_service import ROLE_ADMIN, ROLE_ATHLETE, ROLE_TRAINER, RoleService
-from services import ws_athletes
+from services import get_athletes_worksheet
 from utils.roles import require_roles
 
 router = Router()
@@ -24,7 +24,9 @@ start_kb = ReplyKeyboardMarkup(
 
 
 @router.message(Command("reg"), require_roles(ROLE_TRAINER, ROLE_ADMIN))
-@router.message(require_roles(ROLE_TRAINER, ROLE_ADMIN), lambda m: m.text == "Реєстрація")
+@router.message(
+    require_roles(ROLE_TRAINER, ROLE_ADMIN), lambda m: m.text == "Реєстрація"
+)
 async def cmd_reg(message: types.Message) -> None:
     """Request athlete contact."""
     kb = ReplyKeyboardMarkup(
@@ -40,7 +42,15 @@ async def reg_contact(message: types.Message, role_service: RoleService) -> None
     """Save athlete contact."""
     contact = message.contact
     try:
-        ws_athletes.append_row(
+        worksheet = get_athletes_worksheet()
+    except RuntimeError:
+        await message.answer(
+            "Не вдалося отримати доступ до таблиці спортсменів. Спробуйте пізніше."
+        )
+        return
+
+    try:
+        worksheet.append_row(
             [
                 contact.user_id,
                 contact.first_name or "",

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -12,7 +12,7 @@ from aiogram.fsm.state import State, StatesGroup
 from handlers.menu import build_menu_keyboard
 from menu_callbacks import CB_MENU_INVITE
 from role_service import ROLE_ATHLETE, ROLE_TRAINER, RoleService
-from services import get_bot, ws_athletes
+from services import get_athletes_worksheet, get_bot
 from utils.roles import require_roles
 
 logger = logging.getLogger(__name__)
@@ -75,7 +75,16 @@ async def process_name(
     code = data.get("code")
     name = message.text or ""
     try:
-        ws_athletes.append_row(
+        worksheet = get_athletes_worksheet()
+    except RuntimeError as exc:
+        logger.error("Failed to access athletes worksheet: %s", exc)
+        await message.answer(
+            "Не вдалося отримати доступ до таблиці спортсменів. Спробуйте пізніше."
+        )
+        return
+
+    try:
+        worksheet.append_row(
             [
                 message.from_user.id,
                 name,

--- a/handlers/reports.py
+++ b/handlers/reports.py
@@ -15,7 +15,7 @@ from aiogram.types import BufferedInputFile, Message
 from i18n import t
 from reports import AttemptReport, SegmentReportRow, generate_image_report
 from role_service import RoleService
-from services import ws_pr, ws_results
+from services import get_pr_worksheet, get_results_worksheet
 from utils import get_segments
 
 router = Router()
@@ -119,7 +119,11 @@ def _load_last_result(athlete_id: int) -> ResultPayload | None:
     """Return latest attempt for the athlete."""
 
     try:
-        rows = ws_results.get_all_values()
+        worksheet = get_results_worksheet()
+        rows = worksheet.get_all_values()
+    except RuntimeError as exc:
+        logging.error("Failed to access results worksheet: %s", exc, exc_info=True)
+        return None
     except Exception as exc:  # pragma: no cover - network dependent
         logging.error("Failed to load results: %s", exc, exc_info=True)
         return None
@@ -137,7 +141,11 @@ def _load_best_total(athlete_id: int, stroke: str, distance: int) -> float | Non
     """Return best total time for an athlete stroke/distance pair."""
 
     try:
-        rows = ws_results.get_all_values()
+        worksheet = get_results_worksheet()
+        rows = worksheet.get_all_values()
+    except RuntimeError as exc:
+        logging.error("Failed to access results worksheet: %s", exc, exc_info=True)
+        return None
     except Exception as exc:  # pragma: no cover - network dependent
         logging.error("Failed to load totals: %s", exc, exc_info=True)
         return None
@@ -163,7 +171,11 @@ def _load_segment_bests(
     """Return best split per segment together with their timestamps."""
 
     try:
-        rows = ws_pr.get_all_values()
+        worksheet = get_pr_worksheet()
+        rows = worksheet.get_all_values()
+    except RuntimeError as exc:
+        logging.error("Failed to access PR worksheet: %s", exc, exc_info=True)
+        return [(None, None)] * segments_count
     except Exception as exc:  # pragma: no cover - network dependent
         logging.error("Failed to load segment PRs: %s", exc, exc_info=True)
         return [(None, None)] * segments_count

--- a/handlers/results.py
+++ b/handlers/results.py
@@ -10,7 +10,7 @@ from aiogram.filters import Command
 
 from i18n import t
 from role_service import RoleService
-from services import ws_pr, ws_results
+from services import get_pr_worksheet, get_results_worksheet
 from utils import fmt_time
 
 router = Router()
@@ -22,7 +22,11 @@ def _collect_best_totals(athlete_id: int) -> Dict[RecordKey, float]:
     """Return best total time per (stroke, distance)."""
 
     try:
-        rows = ws_results.get_all_values()
+        worksheet = get_results_worksheet()
+        rows = worksheet.get_all_values()
+    except RuntimeError as exc:
+        logging.error("Failed to access results worksheet: %s", exc, exc_info=True)
+        return {}
     except Exception as exc:  # pragma: no cover - network dependent
         logging.error("Failed to load results for totals: %s", exc, exc_info=True)
         return {}
@@ -55,7 +59,11 @@ def _collect_segment_bests(athlete_id: int) -> Dict[RecordKey, Dict[int, float]]
     """Return best segment times grouped by stroke and distance."""
 
     try:
-        rows = ws_pr.get_all_values()
+        worksheet = get_pr_worksheet()
+        rows = worksheet.get_all_values()
+    except RuntimeError as exc:
+        logging.error("Failed to access PR worksheet: %s", exc, exc_info=True)
+        return {}
     except Exception as exc:  # pragma: no cover - network dependent
         logging.error("Failed to load segment PRs: %s", exc, exc_info=True)
         return {}

--- a/tests/test_reports_i18n.py
+++ b/tests/test_reports_i18n.py
@@ -9,8 +9,12 @@ from i18n import reset_context_language, set_context_language, t
 
 def _load_reports_module(monkeypatch: pytest.MonkeyPatch):
     fake_services = types.ModuleType("services")
-    fake_services.ws_pr = types.SimpleNamespace(get_all_values=lambda: [])
-    fake_services.ws_results = types.SimpleNamespace(get_all_values=lambda: [])
+
+    def _empty_results_sheet():
+        return types.SimpleNamespace(get_all_values=lambda: [])
+
+    fake_services.get_pr_worksheet = _empty_results_sheet
+    fake_services.get_results_worksheet = _empty_results_sheet
     monkeypatch.setitem(sys.modules, "services", fake_services)
     module_name = "handlers.reports"
     if module_name in sys.modules:

--- a/tests/test_results_i18n.py
+++ b/tests/test_results_i18n.py
@@ -11,8 +11,12 @@ from utils import fmt_time
 @pytest.mark.parametrize("lang", ["uk", "ru"])
 def test_result_card_translates_between_languages(monkeypatch, lang: str) -> None:
     fake_services = types.ModuleType("services")
-    fake_services.ws_pr = types.SimpleNamespace(get_all_values=lambda: [])
-    fake_services.ws_results = types.SimpleNamespace(get_all_values=lambda: [])
+
+    def _empty_results_sheet():
+        return types.SimpleNamespace(get_all_values=lambda: [])
+
+    fake_services.get_pr_worksheet = _empty_results_sheet
+    fake_services.get_results_worksheet = _empty_results_sheet
     monkeypatch.setitem(sys.modules, "services", fake_services)
     module = importlib.import_module("handlers.results")
     format_result_card = module.format_result_card

--- a/tests/test_stats_service_i18n.py
+++ b/tests/test_stats_service_i18n.py
@@ -19,10 +19,18 @@ def format_result_summary(monkeypatch: pytest.MonkeyPatch):
 
     services_stub = types.ModuleType("services")
     services_stub.__path__ = []  # mark as package for submodule imports
-    services_stub.ws_athletes = object()
-    services_stub.ws_log = object()
-    services_stub.ws_pr = object()
-    services_stub.ws_results = object()
+
+    empty_sheet = types.SimpleNamespace(
+        get_all_values=lambda: [],
+        append_row=lambda *args, **kwargs: None,
+        update=lambda *args, **kwargs: None,
+        cell=lambda *args, **kwargs: types.SimpleNamespace(value=""),
+    )
+
+    services_stub.get_athletes_worksheet = lambda: empty_sheet
+    services_stub.get_log_worksheet = lambda: empty_sheet
+    services_stub.get_pr_worksheet = lambda: empty_sheet
+    services_stub.get_results_worksheet = lambda: empty_sheet
     monkeypatch.setitem(sys.modules, "services", services_stub)
 
     stats_stub = types.ModuleType("services.stats_service")

--- a/tests/test_turn_analytics.py
+++ b/tests/test_turn_analytics.py
@@ -30,10 +30,13 @@ def progress_module() -> types.ModuleType:
 
     services_stub = types.ModuleType("services")
     services_stub.__path__ = [str(PROJECT_ROOT / "services")]
-    services_stub.ws_athletes = SimpleNamespace(
+
+    services_stub.get_athletes_worksheet = lambda: SimpleNamespace(
         get_all_values=lambda: [], get_all_records=lambda: []
     )
-    services_stub.ws_results = SimpleNamespace(get_all_values=lambda: [])
+    services_stub.get_results_worksheet = lambda: SimpleNamespace(
+        get_all_values=lambda: []
+    )
     monkeypatch.setitem(sys.modules, "services", services_stub)
     monkeypatch.setitem(sys.modules, "services.stats_service", stats_module)
 
@@ -167,12 +170,8 @@ def test_grouping_and_plots_produce_png(
     assert sessions[0]["turns"][0]["turn_number"] == 1
     athlete_name = sample_turn_rows[0]["athlete_name"]
 
-    efficiency_plot = build_turn_efficiency_plot(
-        sessions, athlete_name, "breaststroke"
-    )
-    comparison_plot = build_turn_comparison_plot(
-        sessions, athlete_name, "breaststroke"
-    )
+    efficiency_plot = build_turn_efficiency_plot(sessions, athlete_name, "breaststroke")
+    comparison_plot = build_turn_comparison_plot(sessions, athlete_name, "breaststroke")
     heatmap_plot = build_turn_heatmap(sessions, athlete_name, "breaststroke")
 
     for image in (efficiency_plot, comparison_plot, heatmap_plot):


### PR DESCRIPTION
## Summary
- add cached helpers that lazily load the Google Sheets client, spreadsheet, and worksheets with clearer RuntimeError messages when configuration is missing
- update handlers to call the new worksheet accessors with better error handling and adjust tests to stub the helpers for offline execution

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68e4e424f4a483258c80de17fb4999ae