### PR TITLE
Normalize shell script line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize line endings for executable scripts
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf


### PR DESCRIPTION
## Summary
- add a .gitattributes file to enforce LF endings for shell and related scripts

## Testing
- pip install -r requirements.txt
- pytest -q
- docker compose build *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5862ceef88325aec88bba1896dd66